### PR TITLE
Fixes for #50 and #51

### DIFF
--- a/tests/test_ft_basepoller.py
+++ b/tests/test_ft_basepoller.py
@@ -26,7 +26,6 @@ import time
 import shutil
 import logging
 import gc
-import calendar
 
 import minemeld.ft.basepoller
 
@@ -38,7 +37,7 @@ CUR_LOGICAL_TIME = 0
 
 
 def logical_millisec(*args):
-    return CUR_LOGICAL_TIME
+    return CUR_LOGICAL_TIME*1000
 
 
 def gevent_event_mock_factory():
@@ -155,7 +154,7 @@ class MineMeldFTBasePollerTests(unittest.TestCase):
     @mock.patch.object(gevent, 'spawn_later')
     @mock.patch.object(gevent, 'sleep', side_effect=gevent.GreenletExit())
     @mock.patch('gevent.event.Event', side_effect=gevent_event_mock_factory)
-    @mock.patch.object(calendar, 'timegm', side_effect=logical_millisec)
+    @mock.patch('minemeld.ft.basepoller.utc_millisec', side_effect=logical_millisec)
     def test_delta_feed(self, um_mock, event_mock, sleep_mock, spawnl_mock, spawn_mock):
         global CUR_LOGICAL_TIME
 
@@ -231,7 +230,7 @@ class MineMeldFTBasePollerTests(unittest.TestCase):
     @mock.patch.object(gevent, 'spawn_later')
     @mock.patch.object(gevent, 'sleep', side_effect=gevent.GreenletExit())
     @mock.patch('gevent.event.Event', side_effect=gevent_event_mock_factory)
-    @mock.patch.object(calendar, 'timegm', side_effect=logical_millisec)
+    @mock.patch('minemeld.ft.basepoller.utc_millisec', side_effect=logical_millisec)
     def test_rolling_feed(self, um_mock, event_mock, sleep_mock,
                           spawnl_mock, spawn_mock):
         global CUR_LOGICAL_TIME
@@ -308,7 +307,7 @@ class MineMeldFTBasePollerTests(unittest.TestCase):
     @mock.patch.object(gevent, 'spawn_later')
     @mock.patch.object(gevent, 'sleep', side_effect=gevent.GreenletExit())
     @mock.patch('gevent.event.Event', side_effect=gevent_event_mock_factory)
-    @mock.patch.object(calendar, 'timegm', side_effect=logical_millisec)
+    @mock.patch('minemeld.ft.basepoller.utc_millisec', side_effect=logical_millisec)
     def test_permanent_feed(self, um_mock, event_mock,
                             sleep_mock, spawnl_mock, spawn_mock):
         global CUR_LOGICAL_TIME

--- a/tests/test_ft_local.py
+++ b/tests/test_ft_local.py
@@ -80,7 +80,7 @@ class MineMeldYamlFTTests(unittest.TestCase):
     @mock.patch.object(gevent, 'spawn_later')
     @mock.patch.object(gevent, 'sleep', side_effect=gevent.GreenletExit())
     @mock.patch('gevent.event.Event', side_effect=gevent_event_mock_factory)
-    @mock.patch.object(calendar, 'timegm', side_effect=logical_millisec)
+    @mock.patch('minemeld.ft.basepoller.utc_millisec', side_effect=logical_millisec)
     def test_yaml(self, um_mock, sleep_mock, event_mock,
                   spawnl_mock, spawn_mock):
         global CUR_LOGICAL_TIME

--- a/tests/test_ft_taxii.py
+++ b/tests/test_ft_taxii.py
@@ -1,0 +1,256 @@
+#  Copyright 2016 Palo Alto Networks, Inc
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""FT TAXII tests
+
+Unit tests for minemeld.ft.taxii
+"""
+
+import gevent.monkey
+gevent.monkey.patch_all(thread=False, select=False)
+
+import unittest
+import mock
+
+import redis
+import gevent
+import greenlet
+import time
+import xmltodict
+
+import minemeld.ft.taxii
+import minemeld.ft
+
+FTNAME = 'testft-%d' % int(time.time())
+
+
+class MineMeldFTTaxiiTests(unittest.TestCase):
+    @mock.patch.object(redis, 'StrictRedis')
+    @mock.patch.object(gevent, 'Greenlet')
+    def test_datafeed_init(self, glet_mock, SR_mock):
+        config = {}
+        chassis = mock.Mock()
+
+        b = minemeld.ft.taxii.DataFeed(FTNAME, chassis, config)
+
+        self.assertEqual(b.name, FTNAME)
+        self.assertEqual(b.chassis, chassis)
+        self.assertEqual(b.config, config)
+        self.assertItemsEqual(b.inputs, [])
+        self.assertEqual(b.output, None)
+        self.assertEqual(b.redis_skey, FTNAME)
+        self.assertEqual(b.redis_skey_chkp, FTNAME+'.chkp')
+        self.assertEqual(b.redis_skey_value, FTNAME+'.value')
+
+    @mock.patch.object(redis, 'StrictRedis')
+    @mock.patch.object(gevent, 'Greenlet')
+    def test_datafeed_update_ip(self, glet_mock, SR_mock):
+        config = {}
+        chassis = mock.Mock()
+
+        chassis.request_sub_channel.return_value = None
+        ochannel = mock.Mock()
+        chassis.request_pub_channel.return_value = ochannel
+        chassis.request_rpc_channel.return_value = None
+        rpcmock = mock.Mock()
+        rpcmock.get.return_value = {'error': None, 'result': 'OK'}
+        chassis.send_rpc.return_value = rpcmock
+
+        b = minemeld.ft.taxii.DataFeed(FTNAME, chassis, config)
+
+        inputs = ['a']
+        output = False
+
+        b.connect(inputs, output)
+        b.mgmtbus_initialize()
+
+        b.start()
+        # __init__ + get chkp + delete chkp
+        self.assertEqual(len(SR_mock.mock_calls), 3)
+        SR_mock.reset_mock()
+
+        # unicast
+        b.update(
+            'a',
+            indicator='1.1.1.1',
+            value={
+                'type': 'IPv4',
+                'confidence': 100,
+                'share_level': 'green',
+                'sources': ['test.1']
+            }
+        )
+        for call in SR_mock.mock_calls:
+            name, args, kwargs = call
+            if name == '().pipeline().__enter__().hset':
+                break
+        else:
+            self.fail(msg='hset not found')
+
+        stixdict = xmltodict.parse(args[2])
+        indicator = stixdict['stix:STIX_Package']['stix:Indicators']['stix:Indicator']
+        cyboxprops = indicator['indicator:Observable']['cybox:Object']['cybox:Properties']
+        self.assertEqual(cyboxprops['AddressObj:Address_Value'], '1.1.1.1')
+        SR_mock.reset_mock()
+
+        # CIDR
+        b.update(
+            'a',
+            indicator='1.1.1.0/24',
+            value={
+                'type': 'IPv4',
+                'confidence': 100,
+                'share_level': 'green',
+                'sources': ['test.1']
+            }
+        )
+        for call in SR_mock.mock_calls:
+            name, args, kwargs = call
+            if name == '().pipeline().__enter__().hset':
+                break
+        else:
+            self.fail(msg='hset not found')
+
+        stixdict = xmltodict.parse(args[2])
+        indicator = stixdict['stix:STIX_Package']['stix:Indicators']['stix:Indicator']
+        cyboxprops = indicator['indicator:Observable']['cybox:Object']['cybox:Properties']
+        self.assertEqual(cyboxprops['AddressObj:Address_Value'], '1.1.1.0/24')
+        SR_mock.reset_mock()
+
+        # fake range
+        b.update(
+            'a',
+            indicator='1.1.1.1-1.1.1.1',
+            value={
+                'type': 'IPv4',
+                'confidence': 100,
+                'share_level': 'green',
+                'sources': ['test.1']
+            }
+        )
+        for call in SR_mock.mock_calls:
+            name, args, kwargs = call
+            if name == '().pipeline().__enter__().hset':
+                break
+        else:
+            self.fail(msg='hset not found')
+
+        stixdict = xmltodict.parse(args[2])
+        indicator = stixdict['stix:STIX_Package']['stix:Indicators']['stix:Indicator']
+        cyboxprops = indicator['indicator:Observable']['cybox:Object']['cybox:Properties']
+        self.assertEqual(cyboxprops['AddressObj:Address_Value'], '1.1.1.1')
+        SR_mock.reset_mock()
+
+        # fake range 2
+        b.update(
+            'a',
+            indicator='1.1.1.0-1.1.1.31',
+            value={
+                'type': 'IPv4',
+                'confidence': 100,
+                'share_level': 'green',
+                'sources': ['test.1']
+            }
+        )
+        for call in SR_mock.mock_calls:
+            name, args, kwargs = call
+            if name == '().pipeline().__enter__().hset':
+                break
+        else:
+            self.fail(msg='hset not found')
+
+        stixdict = xmltodict.parse(args[2])
+        indicator = stixdict['stix:STIX_Package']['stix:Indicators']['stix:Indicator']
+        cyboxprops = indicator['indicator:Observable']['cybox:Object']['cybox:Properties']
+        self.assertEqual(cyboxprops['AddressObj:Address_Value'], '1.1.1.0/27')
+        SR_mock.reset_mock()
+
+        # real range
+        b.update(
+            'a',
+            indicator='1.1.1.0-1.1.1.33',
+            value={
+                'type': 'IPv4',
+                'confidence': 100,
+                'share_level': 'green',
+                'sources': ['test.1']
+            }
+        )
+        for call in SR_mock.mock_calls:
+            name, args, kwargs = call
+            if name == '().pipeline().__enter__().hset':
+                break
+        else:
+            self.fail(msg='hset not found')
+
+        stixdict = xmltodict.parse(args[2])
+        indicator = stixdict['stix:STIX_Package']['stix:Indicators']['stix:Indicator']
+        cyboxprops = indicator['indicator:Observable']['cybox:Object']['cybox:Properties']
+        self.assertEqual(cyboxprops['AddressObj:Address_Value'], '1.1.1.0-1.1.1.33')
+        SR_mock.reset_mock()
+
+        b.stop()
+
+    @mock.patch.object(redis, 'StrictRedis')
+    @mock.patch.object(gevent, 'Greenlet')
+    def test_datafeed_update_domain(self, glet_mock, SR_mock):
+        config = {}
+        chassis = mock.Mock()
+
+        chassis.request_sub_channel.return_value = None
+        ochannel = mock.Mock()
+        chassis.request_pub_channel.return_value = ochannel
+        chassis.request_rpc_channel.return_value = None
+        rpcmock = mock.Mock()
+        rpcmock.get.return_value = {'error': None, 'result': 'OK'}
+        chassis.send_rpc.return_value = rpcmock
+
+        b = minemeld.ft.taxii.DataFeed(FTNAME, chassis, config)
+
+        inputs = ['a']
+        output = False
+
+        b.connect(inputs, output)
+        b.mgmtbus_initialize()
+
+        b.start()
+        # __init__ + get chkp + delete chkp
+        self.assertEqual(len(SR_mock.mock_calls), 3)
+        SR_mock.reset_mock()
+
+        # unicast
+        b.update(
+            'a',
+            indicator='example.com',
+            value={
+                'type': 'domain',
+                'confidence': 100,
+                'share_level': 'green',
+                'sources': ['test.1']
+            }
+        )
+        for call in SR_mock.mock_calls:
+            name, args, kwargs = call
+            if name == '().pipeline().__enter__().hset':
+                break
+        else:
+            self.fail(msg='hset not found')
+
+        stixdict = xmltodict.parse(args[2])
+        indicator = stixdict['stix:STIX_Package']['stix:Indicators']['stix:Indicator']
+        cyboxprops = indicator['indicator:Observable']['cybox:Object']['cybox:Properties']
+        self.assertEqual(cyboxprops['DomainNameObj:Value'], 'example.com')
+        SR_mock.reset_mock()
+
+        b.stop()

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ basedeps = mock
            nose
            coverage
            guppy
+           xmltodict
 changedir = {envtmpdir}
 setenv = PYTHONPATH = {toxinidir}
 deps = {[testenv:py27]basedeps}


### PR DESCRIPTION
Fixed PaloAltoNetworks/minemeld-core#50 and PaloAltoNetworks/minemeld-core#51

Fixed some tests mock.patch after utc_millisec has been swicthed to time.time

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>