### PR TITLE
Added session based authorization to API.

### DIFF
--- a/minemeld/flask/__init__.py
+++ b/minemeld/flask/__init__.py
@@ -22,6 +22,7 @@ import logging
 
 from . import config
 from . import aaa
+from . import session
 
 
 LOG = logging.getLogger(__name__)
@@ -36,6 +37,7 @@ else:
     app.logger.setLevel(logging.INFO)
 
 aaa.LOGIN_MANAGER.init_app(app)
+session.init_app(app)
 
 
 try:
@@ -310,6 +312,9 @@ try:
 
 except ImportError:
     LOG.exception("supervisor and psutil needed for supervisor entrypoint")
+
+# login
+from . import login
 
 # prototypes
 from . import prototypeapi  # noqa

--- a/minemeld/flask/aaa.py
+++ b/minemeld/flask/aaa.py
@@ -1,4 +1,4 @@
-#  Copyright 2015 Palo Alto Networks, Inc
+#  Copyright 2015-2016 Palo Alto Networks, Inc
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -153,6 +153,19 @@ def request_loader(request):
         return MMAuthenticatedUser(id=user)
 
     return None
+
+
+@LOGIN_MANAGER.user_loader
+def user_loader(id_):
+    LOG.debug('Loaded user: %s', id_)
+    return MMAuthenticatedUser(id=id_)
+
+
+def check_user(username, password):
+    if not USERS.check_password(username, password):
+        return None
+
+    return MMAuthenticatedUser(id=username)
 
 
 @LOGIN_MANAGER.unauthorized_handler

--- a/minemeld/flask/configapi.py
+++ b/minemeld/flask/configapi.py
@@ -1,4 +1,4 @@
-#  Copyright 2015 Palo Alto Networks, Inc
+#  Copyright 2015-2016 Palo Alto Networks, Inc
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/minemeld/flask/login.py
+++ b/minemeld/flask/login.py
@@ -1,0 +1,49 @@
+#  Copyright 2015-2016 Palo Alto Networks, Inc
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+
+from flask import request
+from flask import jsonify
+
+import flask.ext.login
+
+from . import app
+from . import aaa
+
+LOG = logging.getLogger(__name__)
+
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    username = request.values.get('u')
+    if username is None:
+        return jsonify(error='Missing username'), 400
+
+    password = request.values.get('p')
+    if password is None:
+        return jsonify(error='Missing password'), 400
+
+    user = aaa.check_user(username, password)
+    if user is None:
+        return jsonify(error="Wrong credentials"), 401
+
+    flask.ext.login.login_user(user)
+    return 'OK'
+
+
+@app.route('/logout', methods=['GET'])
+def logout():
+    flask.ext.login.logout_user()
+    return 'OK'

--- a/minemeld/flask/session.py
+++ b/minemeld/flask/session.py
@@ -1,0 +1,100 @@
+#  Copyright 2015-2016 Palo Alto Networks, Inc
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+import ujson
+import datetime
+import uuid
+import redis
+import werkzeug.datastructures
+import flask.sessions
+
+LOG = logging.getLogger(__name__)
+
+
+class RedisSession(werkzeug.datastructures.CallbackDict, flask.sessions.SessionMixin):
+    def __init__(self, initial=None, sid=None, new=False):
+        def on_update(self):
+            self.modified = True
+        werkzeug.datastructures.CallbackDict.__init__(self, initial, on_update)
+        self.sid = sid
+        self.new = new
+        self.modified = False
+
+
+class RedisSessionInterface(flask.sessions.SessionInterface):
+    serializer = ujson
+    session_class = RedisSession
+
+    def __init__(self, redis_=None, prefix='mm-session:'):
+        if redis_ is None:
+            redis_ = redis.StrictRedis()
+        self.redis = redis_
+        self.prefix = prefix
+
+    def generate_sid(self):
+        return str(uuid.uuid4())
+
+    def get_redis_expiration_time(self, app, session):
+        return datetime.timedelta(minutes=10)
+
+    def open_session(self, app, request):
+        sid = request.cookies.get(app.session_cookie_name)
+        if not sid:
+            sid = self.generate_sid()
+            return self.session_class(sid=sid, new=True)
+
+        val = self.redis.get(self.prefix + sid)
+        if val is not None:
+            data = self.serializer.loads(val)
+            return self.session_class(data, sid=sid)
+
+        return self.session_class(sid=sid, new=True)
+
+    def save_session(self, app, session, response):
+        domain = self.get_cookie_domain(app)
+        if not 'user_id' in session:
+            self.redis.delete(self.prefix + session.sid)
+
+            if session.modified:
+                response.delete_cookie(
+                    app.session_cookie_name,
+                    domain=domain
+                )
+            return
+
+        redis_exp = self.get_redis_expiration_time(app, session)
+        cookie_exp = self.get_expiration_time(app, session)
+        val = self.serializer.dumps(dict(session))
+        self.redis.setex(
+            self.prefix + session.sid,
+            int(redis_exp.total_seconds()),
+            val
+        )
+
+        response.set_cookie(
+            app.session_cookie_name,
+            session.sid,
+            expires=cookie_exp,
+            httponly=True,
+            domain=domain
+        )
+
+
+def init_app(app):
+    app.session_interface = RedisSessionInterface()
+    app.config.update(
+        SESSION_COOKIE_NAME = 'mm-session',
+        SESSION_COOKIE_SECURE = True
+    )


### PR DESCRIPTION
Authentication performed via login API in login.py checks credentials against htpasswd DB
and return a session cookie.
Session cookie is managed via flask session interface in session.py. Sessions are stored
on Redis with fixed expiration.

Added 2 new API /login and /logout