### PR TITLE
STIX observable compositions

### DIFF
--- a/tests/test_ft_taxii_stix_package_1.xml
+++ b/tests/test_ft_taxii_stix_package_1.xml
@@ -1,0 +1,55 @@
+<!--
+	STIX IP Watchlist mmtest1
+	
+	Copyright (c) 2014, The MITRE Corporation. All rights reserved. 
+    The contents of this file are subject to the terms of the STIX License located at http://stix.mitre.org/about/termsofuse.html.
+    
+	This mmtest1 demonstrates a simple usage of STIX to represent a list of IP address indicators (watchlist of IP addresses). Cyber operations and malware analysis centers often share a list of suspected malicious IP addresses with information about what those IPs might indicate. This STIX package represents a list of three IP addresses with a short dummy description of what they represent.
+	
+	It demonstrates the use of:
+	
+	   * STIX Indicators
+	   * CybOX within STIX
+	   * The CybOX Address Object (IP)
+	   * CybOX Patterns (apply_condition="ANY")
+	   * Controlled vocabularies
+	
+	Created by Mark Davidson
+-->
+<stix:STIX_Package
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:stix="http://stix.mitre.org/stix-1"
+    xmlns:indicator="http://stix.mitre.org/Indicator-2"
+    xmlns:cybox="http://cybox.mitre.org/cybox-2"
+    xmlns:AddressObject="http://cybox.mitre.org/objects#AddressObject-2"
+    xmlns:cyboxVocabs="http://cybox.mitre.org/default_vocabularies-2"
+    xmlns:stixVocabs="http://stix.mitre.org/default_vocabularies-1"
+    xmlns:mmtest1="http://mmtest1.com/"
+    xsi:schemaLocation="
+    http://stix.mitre.org/stix-1 ../stix_core.xsd
+    http://stix.mitre.org/Indicator-2 ../indicator.xsd
+    http://cybox.mitre.org/default_vocabularies-2 ../cybox/cybox_default_vocabularies.xsd
+    http://stix.mitre.org/default_vocabularies-1 ../stix_default_vocabularies.xsd
+    http://cybox.mitre.org/objects#AddressObject-2 ../cybox/objects/Address_Object.xsd"
+    id="mmtest1:STIXPackage-33fe3b22-0201-47cf-85d0-97c02164528d"
+    timestamp="2014-05-08T09:00:00.000000Z"
+    version="1.1.1"
+    >
+    <stix:STIX_Header>
+        <stix:Title>mmtest1 watchlist that contains IP information.</stix:Title>
+        <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Indicators - Watchlist</stix:Package_Intent>
+    </stix:STIX_Header>
+    <stix:Indicators>
+        <stix:Indicator xsi:type="indicator:IndicatorType" id="mmtest1:Indicator-33fe3b22-0201-47cf-85d0-97c02164528d" timestamp="2014-05-08T09:00:00.000000Z">
+            <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
+            <indicator:Description>Sample IP Address Indicator for this watchlist. This contains one indicator with a set of three IP addresses in the watchlist.</indicator:Description>
+            <indicator:Observable  id="mmtest1:Observable-1c798262-a4cd-434d-a958-884d6980c459">
+                <cybox:Object id="mmtest1:Object-1980ce43-8e03-490b-863a-ea404d12242e">
+                    <cybox:Properties xsi:type="AddressObject:AddressObjectType" category="ipv4-addr">
+                        <AddressObject:Address_Value condition="Equals" apply_condition="ANY">10.0.0.0##comma##10.0.0.1##comma##10.0.0.2</AddressObject:Address_Value>
+                    </cybox:Properties>
+                </cybox:Object>
+            </indicator:Observable>
+        </stix:Indicator>
+    </stix:Indicators>
+</stix:STIX_Package>


### PR DESCRIPTION
This change adds support for STIX Observable Composition. Limitations:
- only OR composition
- only 1 level of composition (no compositions of compositions of ...)
- observables inside composition should be referenced.

Added quick and dirty test for it.

