### PR TITLE
Forced AMQP default to 127.0.0.1

### DIFF
--- a/minemeld/comm/amqp.py
+++ b/minemeld/comm/amqp.py
@@ -400,6 +400,10 @@ class AMQPSubChannel(object):
 class AMQP(object):
     def __init__(self, config):
         self.num_connections = config.pop('num_connections', 1)
+
+        if 'host' not in config:
+            config['host'] = '127.0.0.1'
+
         self.amqp_config = config
 
         self.rpc_server_channels = {}


### PR DESCRIPTION
Instead of localhost. Avoid issues with gevent problems in parsing /etc/hosts file

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>