### PR TITLE
Removes localhost, clean up session interface and adds init to config

### DIFF
--- a/minemeld/flask/__init__.py
+++ b/minemeld/flask/__init__.py
@@ -27,6 +27,9 @@ from . import session
 
 LOG = logging.getLogger(__name__)
 
+REDIS_URL = config.get('REDIS_URL', 'redis://127.0.0.1:6379/0')
+
+
 # create flask app and load config from vmsh.config.api module
 app = Flask(__name__)
 
@@ -37,7 +40,7 @@ else:
     app.logger.setLevel(logging.INFO)
 
 aaa.LOGIN_MANAGER.init_app(app)
-session.init_app(app)
+session.init_app(app, REDIS_URL)
 
 
 try:
@@ -254,8 +257,7 @@ try:
     def get_SR():
         SR = getattr(g, '_redis_client', None)
         if SR is None:
-            redis_url = config.get('REDIS_URL', 'redis://localhost:6379/0')
-            SR = redis.StrictRedis.from_url(redis_url)
+            SR = redis.StrictRedis.from_url(REDIS_URL)
             g._redis_client = SR
         return SR
 
@@ -273,6 +275,8 @@ try:
     from . import taxiidiscovery  # noqa
     from . import taxiicollmgmt  # noqa
     from . import taxiipoll  # noqa
+
+    configapi.init_app(app)
 
 except ImportError:
     LOG.exception("redis is needed for feed and config entrypoints")

--- a/minemeld/flask/configapi.py
+++ b/minemeld/flask/configapi.py
@@ -671,3 +671,16 @@ def append_config_data(datafilename):
         MMRpcClient.send_cmd(hup, 'hup', {'source': 'minemeld-web'})
 
     return jsonify(result='ok')
+
+
+@_redlock
+def _init_config():
+    try:
+        _config_info(lock=False)
+
+    except ValueError:
+        LOG.info('Loading running config in memory')
+        _load_running_config()
+
+def init_app(app):
+    app.before_first_request(_init_config)

--- a/minemeld/flask/session.py
+++ b/minemeld/flask/session.py
@@ -64,7 +64,7 @@ class RedisSessionInterface(flask.sessions.SessionInterface):
 
     def save_session(self, app, session, response):
         domain = self.get_cookie_domain(app)
-        if not 'user_id' in session:
+        if 'user_id' not in session:
             self.redis.delete(self.prefix + session.sid)
 
             if session.modified:
@@ -92,9 +92,12 @@ class RedisSessionInterface(flask.sessions.SessionInterface):
         )
 
 
-def init_app(app):
-    app.session_interface = RedisSessionInterface()
+def init_app(app, redis_url):
+    app.session_interface = RedisSessionInterface(
+        redis_=redis.StrictRedis.from_url(redis_url)
+    )
+
     app.config.update(
-        SESSION_COOKIE_NAME = 'mm-session',
-        SESSION_COOKIE_SECURE = True
+        SESSION_COOKIE_NAME='mm-session',
+        SESSION_COOKIE_SECURE=True
     )

--- a/minemeld/ft/logstash.py
+++ b/minemeld/ft/logstash.py
@@ -33,7 +33,7 @@ class LogstashOutput(base.BaseFT):
     def configure(self):
         super(LogstashOutput, self).configure()
 
-        self.logstash_host = self.config.get('logstash_host', 'localhost')
+        self.logstash_host = self.config.get('logstash_host', '127.0.0.1')
         self.logstash_port = int(self.config.get('logstash_port', '5514'))
 
     def connect(self, inputs, output):

--- a/minemeld/ft/redis.py
+++ b/minemeld/ft/redis.py
@@ -36,7 +36,7 @@ class RedisSet(base.BaseFT):
     def configure(self):
         super(RedisSet, self).configure()
 
-        self.redis_host = self.config.get('redis_host', 'localhost')
+        self.redis_host = self.config.get('redis_host', '127.0.0.1')
         self.redis_port = self.config.get('redis_port', 6379)
         self.redis_password = self.config.get('redis_password', None)
         self.redis_db = self.config.get('redis_db', 0)

--- a/minemeld/ft/taxii.py
+++ b/minemeld/ft/taxii.py
@@ -749,7 +749,7 @@ class DataFeed(base.BaseFT):
     def configure(self):
         super(DataFeed, self).configure()
 
-        self.redis_host = self.config.get('redis_host', 'localhost')
+        self.redis_host = self.config.get('redis_host', '127.0.0.1')
         self.redis_port = self.config.get('redis_port', 6379)
         self.redis_password = self.config.get('redis_password', None)
         self.redis_db = self.config.get('redis_db', 0)

--- a/minemeld/traced/queryprocessor.py
+++ b/minemeld/traced/queryprocessor.py
@@ -49,7 +49,7 @@ class Query(gevent.Greenlet):
         self.starting_counter = counter
         self.num_lines = num_lines
 
-        self.redis_host = redis_config.get('host', 'localhost')
+        self.redis_host = redis_config.get('host', '127.0.0.1')
         self.redis_port = redis_config.get('port', 6379)
         self.redis_password = redis_config.get('password', None)
         self.redis_db = redis_config.get('db', 0)


### PR DESCRIPTION
- removes references to localhost, using 127.0.0.1 instead to avoid DNS issues
- redis connection settings are now passed to the session init function instead of using the defaults
- configapi now loads config before first request

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>