### PR TITLE
Added status streaming functionalities to node (and other tweaks)

### DIFF
--- a/minemeld/chassis.py
+++ b/minemeld/chassis.py
@@ -61,6 +61,7 @@ class Chassis(object):
         )
         self.mgmtbus.add_failure_listener(self.mgmtbus_failed)
         self.log_channel = self.mgmtbus.request_log_channel()
+        self.status_channel = self.mgmtbus.request_status_channel()
 
     def _dynamic_load(self, classname):
         modname, classname = classname.rsplit('.', 1)
@@ -127,6 +128,16 @@ class Chassis(object):
                 'source': nodename,
                 'log_type': log_type,
                 'log': value
+            }
+        )
+
+    def publish_status(self, timestamp, nodename, status):
+        self.status_channel.publish(
+            method='status',
+            params={
+                'timestamp': timestamp,
+                'source': nodename,
+                'status': status
             }
         )
 

--- a/minemeld/comm/amqp.py
+++ b/minemeld/comm/amqp.py
@@ -303,7 +303,7 @@ class AMQPRpcServerChannel(object):
 
 
 class AMQPSubChannel(object):
-    def __init__(self, topic, listeners=None, name=None):
+    def __init__(self, topic, listeners=None, name=None, max_length=None):
         if listeners is None:
             listeners = []
 
@@ -311,6 +311,7 @@ class AMQPSubChannel(object):
         self.channel = None
         self.listeners = listeners
         self.name = name
+        self.max_length = max_length
 
         self.num_callbacks = 0
 
@@ -371,6 +372,9 @@ class AMQPSubChannel(object):
             qdeclare_args['arguments'] = {
                 'x-expires': 10*60*1000  # 10 minutes
             }
+
+            if self.max_length is not None:
+                qdeclare_args['arguments']['x-max-length'] = self.max_length
 
         q = self.channel.queue_declare(
             **qdeclare_args
@@ -449,7 +453,7 @@ class AMQP(object):
         return self.pub_channels[topic]
 
     def request_sub_channel(self, topic, obj=None, allowed_methods=None,
-                            name=None):
+                            name=None, max_length=None):
         if allowed_methods is None:
             allowed_methods = []
 
@@ -460,7 +464,8 @@ class AMQP(object):
         subchannel = AMQPSubChannel(
             topic,
             [(obj, allowed_methods)],
-            name=name
+            name=name,
+            max_length=max_length
         )
         self.sub_channels[topic] = subchannel
 

--- a/minemeld/flask/__init__.py
+++ b/minemeld/flask/__init__.py
@@ -74,7 +74,12 @@ try:
         def _send_cmd(self, method, params={}):
             self._open_channel()
 
-            return self.comm.send_rpc('mbus:master', method, params)
+            return self.comm.send_rpc(
+                'mbus:master',
+                method,
+                params,
+                timeout=10.0
+            )
 
         def status(self):
             return self._send_cmd('status')

--- a/minemeld/mgmtbus.py
+++ b/minemeld/mgmtbus.py
@@ -32,9 +32,14 @@ from __future__ import absolute_import
 import logging
 import uuid
 import collections
+import time
 
 import gevent
 import gevent.event
+import gevent.lock
+
+import redis
+import ujson
 
 import minemeld.comm
 import minemeld.ft
@@ -47,6 +52,7 @@ MGMTBUS_PREFIX = "mbus:"
 MGMTBUS_TOPIC = MGMTBUS_PREFIX+'bus'
 MGMTBUS_MASTER = MGMTBUS_PREFIX+'master'
 MGMTBUS_LOG_TOPIC = MGMTBUS_PREFIX+'log'
+MGMTBUS_STATUS_TOPIC = MGMTBUS_PREFIX+'status'
 
 
 class MgmtbusMaster(object):
@@ -66,8 +72,14 @@ class MgmtbusMaster(object):
         self.comm_config = comm_config
         self.comm_class = comm_class
 
+        self._status_lock = gevent.lock.Semaphore()
         self.status_glet = None
+        self._status_timestamp = int(time.time())*1000
         self._status = {}
+
+        self.SR = redis.StrictRedis.from_url(
+            self.config.get('REDIS_URL', 'redis://127.0.0.1:6379/0')
+        )
 
         self.comm = minemeld.comm.factory(self.comm_class, self.comm_config)
         self._out_channel = self.comm.request_pub_channel(MGMTBUS_TOPIC)
@@ -79,6 +91,13 @@ class MgmtbusMaster(object):
         )
         self._rpc_client = self.comm.request_rpc_fanout_client_channel(
             MGMTBUS_TOPIC
+        )
+        self.comm.request_sub_channel(
+            MGMTBUS_STATUS_TOPIC,
+            self,
+            allowed_methods=['status'],
+            name=MGMTBUS_STATUS_TOPIC+':master',
+            max_length=100
         )
 
     def rpc_status(self):
@@ -297,7 +316,11 @@ class MgmtbusMaster(object):
                 LOG.error('timeout in waiting for status updates from nodes')
             else:
                 result = revt.get(block=False)
-                self._status = result['answers']
+
+                with self._status_lock:
+                    self._status_timestamp = int(time.time()*1000)
+                    self._status = result['answers']
+                LOG.debug('Status: %r', self._status)
 
                 try:
                     self._send_collectd_metrics(
@@ -309,6 +332,42 @@ class MgmtbusMaster(object):
                     LOG.exception('Exception in _status_loop')
 
             gevent.sleep(loop_interval)
+
+    def status(self, timestamp, **kwargs):
+        LOG.debug('Received status: %d - %r', timestamp, kwargs)
+
+        source = kwargs.get('source', None)
+        if source is None:
+            LOG.debug('no source in status report - dropped')
+            return
+
+        status = kwargs.get('status', None)
+        if status is None:
+            LOG.debug('no status in status report - dropped')
+            return
+
+        if self._status_lock.locked():
+            return
+
+        with self._status_lock:
+            if timestamp < self._status_timestamp:
+                return
+
+            self._status['mbus:slave:'+source] = status
+            LOG.debug('updated status %s: %r', source, status)
+
+            try:
+                self.SR.publish(
+                    'mm-engine-status.'+source,
+                    ujson.dumps({
+                        'source': source,
+                        'timestamp': timestamp,
+                        'status': status
+                    })
+                )
+
+            except:
+                LOG.exception('Error publishing status to Redis')
 
     def start_status_monitor(self):
         """Starts status monitor greenlet.
@@ -348,6 +407,12 @@ class MgmtbusSlaveHub(object):
         LOG.debug("Adding log channel")
         return self.comm.request_pub_channel(
             MGMTBUS_LOG_TOPIC
+        )
+
+    def request_status_channel(self):
+        LOG.debug("Adding status channel")
+        return self.comm.request_pub_channel(
+            MGMTBUS_STATUS_TOPIC
         )
 
     def request_channel(self, node):


### PR DESCRIPTION
- nodes can send to state to mgmtbus master
- mgmtbus master collects state notifications and builds graph state
- mgmtbus master forwards state notifications to Redis publish
- added API to receive status notifications from Redis
- added timeout in status/minemeld API to cope with engine restart
- added renice of chassis processes
- fixed a startup logic issue

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>