### PR TITLE
Increased timeout in CIF and fixed logic bug

### DIFF
--- a/minemeld/ft/cif.py
+++ b/minemeld/ft/cif.py
@@ -121,7 +121,9 @@ class Feed(basepoller.BasePollerFT):
                 '%s - token, remote or filters not set, poll not performed',
                 self.name
             )
-            return []
+            raise RuntimeError(
+                '%s - token, remote or filters not set, poll not performed' % self.name
+            )
 
         filters = {}
         filters.update(self.filters)
@@ -145,7 +147,8 @@ class Feed(basepoller.BasePollerFT):
         cifclient = cifsdk.client.Client(
             token=self.token,
             remote=self.remote,
-            verify_ssl=self.verify_cert
+            verify_ssl=self.verify_cert,
+            timeout=900
         )
 
         try:


### PR DESCRIPTION
- increases timeout on CIF Client, for large queries
- if token, remote or filters are not set RuntimeError is raised to not set the last_successful_run value

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>