### PR TITLE
RPC requests are served immediately

### DIFF
--- a/minemeld/comm/amqp.py
+++ b/minemeld/comm/amqp.py
@@ -273,11 +273,6 @@ class AMQPRpcServerChannel(object):
         else:
             self._send_result(reply_to, id_, result=result)
 
-    def _g_callback(self, msg):
-        gevent.spawn(self._callback, msg)
-
-        gevent.sleep(0)
-
     def connect(self, conn):
         if self.channel is not None:
             return
@@ -304,7 +299,7 @@ class AMQPRpcServerChannel(object):
             )
 
         self.channel.basic_consume(
-            callback=self._g_callback,
+            callback=self._callback,
             no_ack=True,
             exclusive=True
         )
@@ -611,7 +606,9 @@ class AMQP(object):
         )
 
         # create RPC servers connection and set the waiter to MAXPRI
-        self._rpc_in_connection = amqp.connection.Connection(**self.amqp_config)
+        self._rpc_in_connection = amqp.connection.Connection(
+            **self.amqp_config
+        )
         self._rpc_in_connection.sock._read_event.priority = gevent.core.MAXPRI
         self._rpc_in_connection.sock._write_event.priority = gevent.core.MAXPRI
 


### PR DESCRIPTION
## Motivation

RPC requests handled by AMQPRpcServerChannel should be served with high priority.
AMQPRpcServerChannel currently spawns a new greenlet per request, the greenlet then is executed by gevent with other callbacks. AMQPRpcServerChannel instead should directly serve the call to not lose the priority.

## Modifications

- consume now directly calls _callback instead of _g_callback
- removed _g_callback

## Result

AMQPRpcServerChannel will serve RPC requests directlty inside the event handling greenlet.

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>