### PR TITLE
Implements AAA API and improves API config management

### DIFF
--- a/minemeld/flask/__init__.py
+++ b/minemeld/flask/__init__.py
@@ -21,6 +21,8 @@ import werkzeug.local
 import logging
 
 from . import config
+config.init()
+
 from . import aaa
 from . import session
 
@@ -30,7 +32,6 @@ LOG = logging.getLogger(__name__)
 REDIS_URL = config.get('REDIS_URL', 'redis://127.0.0.1:6379/0')
 
 
-# create flask app and load config from vmsh.config.api module
 app = Flask(__name__)
 
 app.logger.addHandler(logging.StreamHandler())
@@ -323,13 +324,16 @@ except ImportError:
     LOG.exception("supervisor and psutil needed for supervisor entrypoint")
 
 # login
-from . import login
+from . import login  # noqa
 
 # prototypes
 from . import prototypeapi  # noqa
 
 # validate
 from . import validateapi  # noqa
+
+# aaa api
+from . import aaaapi  # noqa
 
 if 'psutil' in sys.modules and 'amqp' in sys.modules:
     from . import status  # noqa

--- a/minemeld/flask/aaa.py
+++ b/minemeld/flask/aaa.py
@@ -17,7 +17,6 @@ import flask.ext.login
 import logging
 import base64
 import passlib.apache
-import os
 import os.path
 
 from . import config
@@ -25,37 +24,14 @@ from . import config
 
 LOG = logging.getLogger(__name__)
 
-_users_db = config.get('USERS_DB', None)
-if _users_db is None:
-    USERS = passlib.apache.HtpasswdFile(new=True)
-else:
-    _users_db = os.path.join(
-        os.path.dirname(os.environ.get('MM_CONFIG', '')),
-        _users_db
-    )
-    USERS = passlib.apache.HtpasswdFile(path=_users_db)
-
-
-_feeds_users_db = config.get('FEEDS_USERS_DB', None)
-if _feeds_users_db is None:
-    FEEDS_USERS = passlib.apache.HtpasswdFile(new=True)
-else:
-    _feeds_users_db = os.path.join(
-        os.path.dirname(os.environ.get('MM_CONFIG', '')),
-        _feeds_users_db
-    )
-    FEEDS_USERS = passlib.apache.HtpasswdFile(path=_feeds_users_db)
-
 LOGIN_MANAGER = flask.ext.login.LoginManager()
 LOGIN_MANAGER.session_protection = None
-API_AUTH_ENABLED = config.get('API_AUTH_ENABLED', True)
-FEEDS_AUTH_ENABLED = config.get('FEEDS_AUTH_ENABLED', False)
-TAXII_AUTH_ENABLED = config.get('TAXII_AUTH_ENABLED', False)
+ANONYMOUS = 'mm-anonymous'
 
 
 class MMAuthenticatedUser(object):
-    def __init__(self, id=None):
-        self._id = unicode(id)
+    def __init__(self, _id=None):
+        self._id = unicode(_id)
 
     def get_id(self):
         return self._id
@@ -70,102 +46,139 @@ class MMAuthenticatedUser(object):
         return False
 
 
+class MMAuthenticatedAdminUser(MMAuthenticatedUser):
+    def check_feed(self, feedname):
+        return True
+
+
+class MMAnonymousAdminUser(MMAuthenticatedUser):
+    def __init__(self):
+        super(MMAnonymousAdminUser, self).__init__(_id=ANONYMOUS)
+
+    def is_anonymous(self):
+        return True
+
+    def check_feed(self, feedname):
+        return False
+
+
+class MMAuthenticatedFeedUser(MMAuthenticatedUser):
+    def check_feed(self, feedname):
+        fattributes = config.get('FEEDS_ATTRS', None)
+        if fattributes is None or feedname not in fattributes:
+            return False
+        ftags = set(fattributes[feedname].get('tags', []))
+
+        # if 'any' is present, any authenticated user can access
+        # the feed
+        if 'any' in ftags:
+            return True
+
+        uattributes = config.get('FEEDS_USERS_ATTRS', None)
+        if uattributes is None or self._id not in uattributes:
+            return False
+        tags = set(uattributes[self._id].get('tags', []))
+
+        return len(tags.intersection(ftags)) != 0
+
+
+class MMAnonymousFeedUser(MMAuthenticatedUser):
+    def __init__(self, auth_enabled=False):
+        super(MMAnonymousFeedUser, self).__init__(_id=ANONYMOUS)
+
+        self.auth_enabled = auth_enabled
+
+    def check_feed(self, feedname):
+        if not self.auth_enabled:
+            return True
+
+        fattributes = config.get('FEEDS_ATTRS', None)
+        if fattributes is None or feedname not in fattributes:
+            return False
+        ftags = set(fattributes[feedname].get('tags', []))
+
+        if 'anonymous' in ftags:
+            return True
+
+        return False
+
+    def is_anonymous(self):
+        return True
+
+
 def _feeds_request_loader(request):
-    if not FEEDS_AUTH_ENABLED:
-        return MMAuthenticatedUser(id='feeds_auth_disabled')
+    LOG.debug('feed request')
+    if not config.get('FEEDS_AUTH_ENABLED', False):
+        return MMAnonymousFeedUser(auth_enabled=False)
 
     api_key = request.headers.get('Authorization')
-    if api_key is not None:
-        api_key = api_key.replace('Basic', '', 1)
+    if api_key is None:
+        return MMAnonymousFeedUser(auth_enabled=True)
+    
+    api_key = api_key.replace('Basic', '', 1)
 
-        try:
-            api_key = base64.b64decode(api_key)
-        except TypeError:
+    try:
+        api_key = base64.b64decode(api_key)
+    except TypeError:
+        return None
+
+    try:
+        user, password = api_key.split(':', 1)
+    except ValueError:
+        return None
+
+    if not config.get('FEEDS_USERS_DB').check_password(user, password):
+        if not config.get('USERS_DB').check_password(user, password):
             return None
 
-        try:
-            user, password = api_key.split(':', 1)
-        except ValueError:
-            return None
-
-        if not FEEDS_USERS.check_password(user, password):
-            return None
-
-        return MMAuthenticatedUser(id=user)
-
-    return None
-
-
-def _taxii_request_loader(request):
-    if not TAXII_AUTH_ENABLED:
-        return MMAuthenticatedUser(id='taxii_auth_disabled')
-
-    api_key = request.headers.get('Authorization')
-    if api_key is not None:
-        api_key = api_key.replace('Basic', '', 1)
-
-        try:
-            api_key = base64.b64decode(api_key)
-        except TypeError:
-            return None
-
-        try:
-            user, password = api_key.split(':', 1)
-        except ValueError:
-            return None
-
-        if not FEEDS_USERS.check_password(user, password):
-            return None
-
-        return MMAuthenticatedUser(id=user)
-
-    return None
+    return MMAuthenticatedFeedUser(_id=user)
 
 
 @LOGIN_MANAGER.request_loader
 def request_loader(request):
+    # check if this is a feed request
     if request.path.startswith('/taxii-'):
-        return _taxii_request_loader(request)
+        return _feeds_request_loader(request)
 
     if request.path.startswith('/feeds/'):
         return _feeds_request_loader(request)
 
-    if not API_AUTH_ENABLED:
-        return MMAuthenticatedUser(id='api_auth_disabled')
+    # if auth is disabled, proceed
+    if not config.get('API_AUTH_ENABLED', True):
+        return MMAnonymousAdminUser()
 
     api_key = request.headers.get('Authorization')
-    if api_key is not None:
-        api_key = api_key.replace('Basic', '', 1)
+    if api_key is None:
+        return None
 
-        try:
-            api_key = base64.b64decode(api_key)
-        except TypeError:
-            return None
+    api_key = api_key.replace('Basic', '', 1)
 
-        try:
-            user, password = api_key.split(':', 1)
-        except ValueError:
-            return None
+    try:
+        api_key = base64.b64decode(api_key)
+    except TypeError:
+        return None
 
-        if not USERS.check_password(user, password):
-            return None
+    try:
+        user, password = api_key.split(':', 1)
+    except ValueError:
+        return None
 
-        return MMAuthenticatedUser(id=user)
+    if not config.get('USERS_DB').check_password(user, password):
+        return None
 
-    return None
+    return MMAuthenticatedAdminUser(_id=user)
 
 
 @LOGIN_MANAGER.user_loader
-def user_loader(id_):
-    LOG.debug('Loaded user: %s', id_)
-    return MMAuthenticatedUser(id=id_)
+def user_loader(_id):
+    return MMAuthenticatedAdminUser(_id=_id)
 
 
 def check_user(username, password):
-    if not USERS.check_password(username, password):
+    if not config.get('USERS_DB').check_password(username, password):
         return None
 
-    return MMAuthenticatedUser(id=username)
+    return MMAuthenticatedAdminUser(_id=username)
 
 
 @LOGIN_MANAGER.unauthorized_handler

--- a/minemeld/flask/aaaapi.py
+++ b/minemeld/flask/aaaapi.py
@@ -1,0 +1,208 @@
+#  Copyright 2016 Palo Alto Networks, Inc
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+import collections
+
+from flask import request
+from flask import jsonify
+
+import flask.ext.login
+
+from . import app
+from . import config
+
+LOG = logging.getLogger(__name__)
+
+API_USERS_ATTRS_ATTR = 'API_USERS_ATTRS'
+FEEDS_USERS_ATTRS_ATTR = 'FEEDS_USERS_ATTRS'
+FEEDS_ATTRS_ATTR = 'FEEDS_ATTRS'
+
+
+Subsystem = collections.namedtuple(
+    'Subsystem',
+    ['authdb', 'attrs', 'enabled', 'enabled_default'],
+    verbose=True
+)
+
+
+_SUBSYSTEM_MAP = {
+    'api': Subsystem(
+        authdb='USERS_DB',
+        enabled='API_AUTH_ENABLED',
+        enabled_default=True,
+        attrs=config.APIConfigDict(attribute=API_USERS_ATTRS_ATTR, level=50)
+    ),
+    'feeds': Subsystem(
+        authdb='FEEDS_USERS_DB',
+        enabled='FEEDS_AUTH_ENABLED',
+        enabled_default=False,
+        attrs=config.APIConfigDict(attribute=FEEDS_USERS_ATTRS_ATTR, level=50)
+    )
+}
+
+
+_FEEDS_ATTRS = config.APIConfigDict(attribute=FEEDS_ATTRS_ATTR, level=50)
+
+
+@app.route('/aaa/users/<subsystem>', methods=['GET'])
+@flask.ext.login.login_required
+def get_users(subsystem):
+    subsystem = _SUBSYSTEM_MAP.get(subsystem, None)
+    if subsystem is None:
+        return jsonify(error='Invalid subsystem'), 400
+
+    result = {
+        'enabled': config.get(subsystem.enabled, subsystem.enabled_default),
+        'users': {}
+    }
+    users = config.get(subsystem.authdb).users()
+    users_attrs = subsystem.attrs.value()
+    LOG.debug(users_attrs)
+    for u in users:
+        attrs = {}
+        if u in users_attrs:
+            attrs = users_attrs[u]
+        result['users'][u] = attrs
+
+    return jsonify(result=result)
+
+
+@app.route('/aaa/users/<subsystem>/<username>', methods=['PUT'])
+@flask.ext.login.login_required
+def set_user_password(subsystem, username):
+    subsystem = _SUBSYSTEM_MAP.get(subsystem, None)
+    if subsystem is None:
+        return jsonify(error='Invalid subsystem'), 400
+
+    with config.lock():
+        users_db = config.get(subsystem.authdb)
+        if not users_db.path:
+            return jsonify(error='Users database not available')
+
+        try:
+            password = request.get_json()['password']
+        except Exception:
+            return jsonify(error='Invalid request'), 400
+
+        users_db.set_password(username, password)
+        users_db.save()
+
+        return jsonify(result='ok')
+
+
+@app.route('/aaa/users/<subsystem>/<username>/attributes', methods=['POST'])
+@flask.ext.login.login_required
+def set_user_attributes(subsystem, username):
+    subsystem = _SUBSYSTEM_MAP.get(subsystem, None)
+    if subsystem is None:
+        return jsonify(error='Invalid subsystem'), 400
+
+    with config.lock():
+        users_db = config.get(subsystem.authdb)
+        if not users_db.path:
+            return jsonify(error='Users database not available')
+
+        if username not in users_db.users():
+            return jsonify(error='Unknown user'), 400
+
+        try:
+            attributes = request.get_json()
+        except Exception:
+            return jsonify(error='Invalid request'), 400
+
+        if not isinstance(attributes, dict):
+            return jsonify(error='Attributes should be a dict'), 400
+
+        subsystem.attrs.set(username, attributes)
+
+        return jsonify(result='ok')
+
+
+@app.route('/aaa/users/<subsystem>/<username>', methods=['DELETE'])
+@flask.ext.login.login_required
+def delete_user(subsystem, username):
+    subsystem = _SUBSYSTEM_MAP.get(subsystem, None)
+    if subsystem is None:
+        return jsonify(error='Invalid subsystem'), 400
+
+    with config.lock():    
+        users_db = config.get(subsystem.authdb)
+        if not users_db.path:
+            return jsonify(error='Users database not available')
+
+        # delete user from database and tags
+        if users_db.delete(username):
+            users_db.save()
+
+        subsystem.attrs.delete(username)
+
+        return jsonify(result='ok')
+
+
+@app.route('/aaa/feeds', methods=['GET'])
+@flask.ext.login.login_required
+def get_feeds():
+    result = {
+        'enabled': config.get(
+            _SUBSYSTEM_MAP['feeds'].enabled,
+            _SUBSYSTEM_MAP['feeds'].enabled_default
+        ),
+        'feeds': _FEEDS_ATTRS.value()
+    }
+    return jsonify(result=result)
+
+
+@app.route('/aaa/feeds/<feedname>/attributes', methods=['PUT', 'POST'])
+@flask.ext.login.login_required
+def set_feed_attributes(feedname):
+    with config.lock():
+        try:
+            attributes = request.get_json()
+        except Exception:
+            return jsonify(error='Invalid request'), 400
+
+        if not isinstance(attributes, dict):
+            return jsonify(error='Attributes should be a dict'), 400
+
+        _FEEDS_ATTRS.set(feedname, attributes)
+
+        return jsonify(result='ok')
+
+
+@app.route('/aaa/feeds/<feedname>', methods=['DELETE'])
+@flask.ext.login.login_required
+def delete_feed(feedname):
+    with config.lock():
+        _FEEDS_ATTRS.delete(feedname)
+
+        return jsonify(result='ok')
+
+
+@app.route('/aaa/tags', methods=['GET'])
+@flask.ext.login.login_required
+def get_tags():
+    tags = set()
+
+    for _, subsystem in _SUBSYSTEM_MAP.iteritems():
+        for _, attributes in subsystem.attrs.value().iteritems():
+            if 'tags' in attributes:
+                for t in attributes['tags']:
+                    tags.add(t)
+    for _, attributes in _FEEDS_ATTRS.value().iteritems():
+        if 'tags' in attributes:
+            for t in attributes['tags']:
+                tags.add(t)
+
+    return jsonify(result=list(tags - set(['any', 'anonymous'])))

--- a/minemeld/flask/config.py
+++ b/minemeld/flask/config.py
@@ -1,4 +1,4 @@
-#  Copyright 2015 Palo Alto Networks, Inc
+#  Copyright 2015-2016 Palo Alto Networks, Inc
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -13,16 +13,27 @@
 #  limitations under the License.
 
 import os
+
+import gevent
+import logging
+
 import yaml
+import filelock
+import passlib.apache
+
+from . import utils
 
 CONFIG = {}
+API_CONFIG_PATH = None
+API_CONFIG_LOCK = None
 
-_config_path = os.environ.get('MM_CONFIG', None)
+LOG = logging.getLogger(__name__)
+CONFIG_FILES_RE = '^(?:(?:[0-9]+.*\.yml)|(?:.*\.htpasswd))$'
 
-if _config_path is not None:
-    with open(_config_path, 'r') as f:
-        CONFIG = yaml.safe_load(f)
-
+_AUTH_DBS = {
+    'USERS_DB': 'wsgi.htpasswd',
+    'FEEDS_USERS_DB': 'feeds.htpasswd'
+}
 
 def get(key, default=None):
     try:
@@ -45,3 +56,154 @@ def get(key, default=None):
         return result
 
     return default
+
+
+def store(file, value):
+    with API_CONFIG_LOCK.acquire():
+        with open(os.path.join(API_CONFIG_PATH, file), 'w+') as f:
+            yaml.safe_dump(value, stream=f)
+
+
+def lock():
+    return API_CONFIG_LOCK.acquire()
+
+
+class APIConfigDict(object):
+    def __init__(self, attribute, level=50):
+        self.attribute = attribute
+        self.filename = '%d-%s.yml' % (level, attribute.lower().replace('_', '-'))
+
+    def set(self, key, value):
+        curvalues = get(self.attribute, {})
+        curvalues[key] = value
+        store(self.filename, { self.attribute: curvalues })
+
+    def delete(self, key):
+        curvalues = get(self.attribute, {})
+        curvalues.pop(key, None)
+        store(self.filename, { self.attribute: curvalues })
+
+    def value(self):
+        return get(self.attribute, {})
+
+
+def _load_config(config_path):
+    global CONFIG
+    LOG.debug('%r', config_path)
+
+    new_config = {}
+
+    # comptaibilty early releases where all the config
+    # was store in a single file
+    old_config_file = os.path.join(config_path, 'wsgi.yml')
+    if os.path.exists(old_config_file):
+        try:
+            with open(old_config_file, 'r') as f:
+                add_config = yaml.safe_load(f)
+
+            if add_config is not None:
+                new_config.update(add_config)
+        except OSError:
+            pass
+
+    with API_CONFIG_LOCK.acquire():
+        api_config_path = os.path.join(config_path, 'api')
+        if os.path.exists(api_config_path):
+            config_files = sorted(os.listdir(api_config_path))
+
+            for cf in config_files:
+                if not cf.endswith('.yml'):
+                    continue
+
+                try:
+                    with open(os.path.join(api_config_path, cf), 'r') as f:
+                        add_config = yaml.safe_load(f)
+
+                    if add_config is not None:
+                        new_config.update(add_config)
+
+                except (OSError, IOError, ValueError):
+                    LOG.exception('Error loading config file %s' % cf)
+
+    CONFIG = new_config
+    LOG.info('Config loaded: %r', new_config)
+
+
+def _load_auth_dbs(config_path):
+    with API_CONFIG_LOCK.acquire():
+        api_config_path = os.path.join(config_path, 'api')
+        for env, default in _AUTH_DBS.iteritems():
+            dbname = get(env, default)
+            new_db = False
+
+            dbpath = os.path.join(
+                api_config_path,
+                dbname
+            )
+
+            # for compatibility with old releases
+            if not os.path.exists(dbpath):
+                old_dbpath = os.path.join(
+                    config_path,
+                    dbname
+                )
+                if os.path.exists(old_dbpath):
+                    dbpath = old_dbpath
+                else:
+                    new_db = True
+
+            CONFIG[env] = passlib.apache.HtpasswdFile(
+                path=dbpath,
+                new=new_db
+            )
+
+            LOG.info('%s loaded from %s', env, dbpath)
+
+
+def _config_monitor(config_path):
+    api_config_path = os.path.join(config_path, 'api')
+    dirsnapshot = utils.DirSnapshot(api_config_path, CONFIG_FILES_RE)
+    while True:
+        new_snapshot = utils.DirSnapshot(api_config_path, CONFIG_FILES_RE)
+
+        if new_snapshot != dirsnapshot:
+            try:
+                _load_config(config_path)
+                _load_auth_dbs(config_path)
+
+            except gevent.GreenletExit:
+                break
+
+            except:
+                LOG.exception('Error loading config')
+
+            dirsnapshot = new_snapshot
+
+        gevent.sleep(1)
+
+
+# initialization
+def init():
+    global API_CONFIG_PATH
+    global API_CONFIG_LOCK
+
+    logging.basicConfig(level=logging.DEBUG)
+
+    config_path = os.environ.get('MM_CONFIG', None)
+    if config_path is None:
+        LOG.critical('MM_CONFIG environment variable not set')
+        raise RuntimeError('MM_CONFIG environment variable not set')
+
+    if not os.path.isdir(config_path):
+        config_path = os.path.dirname(config_path)
+
+    # init global vars
+    API_CONFIG_PATH = os.path.join(config_path, 'api')
+    API_CONFIG_LOCK = filelock.FileLock(
+        os.path.join(API_CONFIG_PATH, 'config.lock')
+    )
+
+    _load_config(config_path)
+    _load_auth_dbs(config_path)
+    if config_path is not None:
+        gevent.spawn(_config_monitor, config_path)

--- a/minemeld/flask/configapi.py
+++ b/minemeld/flask/configapi.py
@@ -686,5 +686,6 @@ def _init_config():
         LOG.info('Loading running config in memory')
         _load_running_config()
 
+
 def init_app(app):
     app.before_first_request(_init_config)

--- a/minemeld/flask/feedredis.py
+++ b/minemeld/flask/feedredis.py
@@ -24,8 +24,10 @@ from flask import stream_with_context
 import flask.ext.login
 
 from . import app
+from . import aaa
 from . import SR
 from . import MMMaster
+from . import config
 
 LOG = logging.getLogger(__name__)
 FEED_INTERVAL = 100
@@ -168,6 +170,9 @@ _FEED_FORMATS = {
 @app.route('/feeds/<feed>', methods=['GET'])
 @flask.ext.login.login_required
 def get_feed_content(feed):
+    if not flask.ext.login.current_user.check_feed(feed):
+        return 'Unauthorized', 401
+
     # check if feed exists
     status = MMMaster.status()
     tr = status.get('result', None)

--- a/minemeld/flask/metricsapi.py
+++ b/minemeld/flask/metricsapi.py
@@ -90,6 +90,7 @@ def _fetch_metric(cc, metric, type_=None,
 
 
 @app.route('/metrics')
+@flask.ext.login.login_required
 def get_metrics():
     return jsonify(result=_list_metrics())
 

--- a/minemeld/flask/taxiipoll.py
+++ b/minemeld/flask/taxiipoll.py
@@ -140,6 +140,9 @@ def taxii_poll_service():
         excbegtime = tm.exclusive_begin_timestamp_label
         incendtime = tm.inclusive_end_timestamp_label
 
+        if not flask.ext.login.current_user.check_feed(cname):
+            return 'Unauthorized', 401
+
         return data_feed_11(tm.message_id, cname, excbegtime, incendtime)
 
     elif taxiict == 'urn:taxii.mitre.org:message:xml:1.0':

--- a/minemeld/flask/utils.py
+++ b/minemeld/flask/utils.py
@@ -1,0 +1,45 @@
+#  Copyright 2016 Palo Alto Networks, Inc
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+import re
+import logging
+
+LOG = logging.getLogger(__name__)
+
+
+class DirSnapshot(object):
+    def __init__(self, path, regex=None):
+        self._entries = self._init_snapshot(path, regex)
+
+    def _init_snapshot(self, path, regex):
+        result = set()
+
+        files = os.listdir(path)
+        pattern = re.compile(regex) if regex is not None else None
+        for f in files:
+            if pattern is not None:
+                if pattern.match(f) is None:
+                    continue
+
+            mtime = os.stat(os.path.join(path, f)).st_mtime
+            result.add('%s_%d' % (f, int(mtime)))
+
+        return result
+
+    def __eq__(self, other):
+        return self._entries == other._entries
+
+    def __ne__(self, other):
+        return self._entries != other._entries


### PR DESCRIPTION
## Motivation

Users have requested a UI for managing WebUI Admins and for managing credentials for feeds access. 

## Modifications

### MineMeld API process config

- MineMeld API process now reads the configuration from a directory: all the files inside the directory with pattern <number>-*.yml are read in order, merged and treated as config. The config directory is the contents of the environment variable MM_CONFIG + *api*, for compatibility with old releases.
- The config directory can also contain one or more Apache HTPASSWD files where admin/feeds access credentials are stored hashed and salted.
- MineMeld API monitors the directory for changes, if a yml or htpasswd file is added, deleted or modified the config is automatically  reloaded. This happens by polling the directory every second and checking the mtime of the files.

### MineMeld API process AAA

- MineMeld API provides 2 classes of users: API users and feeds users. API users are the WebUI admins. Feeds users are user that can access the feeds. Both API users and feeds users have associated a dictionary of attributes, stored in the process config files and accessible via the API.
- API users credentials are stored in a dedicated htpasswd file, path provided by **USERS_DB**, default *wsgi.htpasswd*. API authentication is controlled by the environment variable **API_AUTH_ENABLED**, default is *true*.
- Feeds users credentials are stored in a dedicated htpasswd file, path provided by **FEEDS_USERS_DB**, default *feeds.htpasswd*. Feeds authentication is controlled by the environment variable **FEEDS_AUTH_ENABLED**, default is *false* for compatibility with old releases.

### MineMeld Output feed authorization

- Each output feed has associated a set of tags.
- Each feed user has in her attributes a *tags* attribute listing the tags she has access to.
- When the feed APIs receive an access request for a feed, they check if the user has access to the one of the tags associated to the requested feed.
- If the feed is tagged with **anonymous**, anonymous access to the feed is permitted even if the authentication is enabled
- If the feed is tagged with **any**, any authenticated user has access to the feed.
- API users have access to all the feeds.

## Result

Improved AAA mechanism for API and config management.

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>