### PR TITLE
Add Cisco ISE IP to SGT miner

### DIFF
--- a/minemeld/ft/ciscoise.py
+++ b/minemeld/ft/ciscoise.py
@@ -1,0 +1,99 @@
+#  Copyright 2016 Palo Alto Networks, Inc
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+import os
+import yaml
+import minemeld.packages.ise.ers
+from . import basepoller
+
+LOG = logging.getLogger(__name__)
+
+
+class ErsSgt(basepoller.BasePollerFT):
+    def configure(self):
+        super(ErsSgt, self).configure()
+
+        self.kwargs = {}
+        for x in ['hostname', 'username', 'password',
+                  'verify_cert', 'timeout']:
+            if x == 'verify_cert':
+                self.kwargs['verify'] = self.config.get(x, None)
+            else:
+                self.kwargs[x] = self.config.get(x, None)
+
+        self.side_config_path = self.config.get('side_config', None)
+        if self.side_config_path is None:
+            self.side_config_path = os.path.join(
+                os.environ['MM_CONFIG_DIR'],
+                '%s_side_config.yml' % self.name
+            )
+
+        self._load_side_config()
+
+        self.prefix = self.config.get('prefix', 'ise_sgt')
+
+        d = self.kwargs.copy()
+        if d['password']:
+            d['password'] = '*' * 6
+        LOG.debug('%s prefix: %s', d, self.prefix)
+
+    def _load_side_config(self):
+        try:
+            with open(self.side_config_path, 'r') as f:
+                sconfig = yaml.safe_load(f)
+
+        except IOError as e:
+            LOG.info('%s - No side config: %s', self.name, e)
+            return
+
+        if sconfig is None:
+            LOG.info('%s - Empty side config: %s', self.name,
+                     self.side_config_path)
+            return
+
+        for x in ['hostname', 'username', 'password',
+                  'verify_cert', 'timeout']:
+            v = sconfig.get(x, None)
+            if v is not None and x == 'verify_cert':
+                self.kwargs['verify'] = v
+            elif v is not None:
+                self.kwargs[x] = v
+
+    def _process_item(self, item):
+        return [[item['ip'], {'type': 'IPv4', self.prefix: item['sgt']}]]
+
+    def _build_iterator(self, now):
+        def indicators(ips_sgts_map):
+            LOG.debug('SGT indicators #%d %s', len(api.ips_sgts_map),
+                      api.ips_sgts_map)
+            for item in ips_sgts_map:
+                yield {'ip': item, 'sgt': ips_sgts_map[item]}
+
+        try:
+            api = minemeld.packages.ise.ers.IseErs(**self.kwargs)
+        except IseErsError as e:
+            # missing arguments
+            x = '%s: poll not performed: %s' % (self.name, e)
+            LOG.info('%s', x)
+            raise RuntimeError(x)
+
+        api.sgts_ips_map()
+
+        return indicators(api.ips_sgts_map)
+
+    def hup(self, source=None):
+        LOG.info('%s - hup received, reload side config', self.name)
+        self._load_side_config()
+        super(ErsSgt, self).hup(source=source)

--- a/minemeld/packages/ise/__init__.py
+++ b/minemeld/packages/ise/__init__.py
@@ -1,0 +1,8 @@
+import logging
+
+DEBUG1 = logging.DEBUG
+DEBUG2 = DEBUG1 - 1
+DEBUG3 = DEBUG2 - 1
+
+logging.addLevelName(DEBUG2, 'DEBUG2')
+logging.addLevelName(DEBUG3, 'DEBUG3')

--- a/minemeld/packages/ise/ers.py
+++ b/minemeld/packages/ise/ers.py
@@ -1,0 +1,290 @@
+#
+# Copyright (c) 2016 Palo Alto Networks, Inc. <techbizdev@paloaltonetworks.com>
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+'''Interface to the Cisco ISE ERS (External RESTful Services) API
+
+The interface is specific to requirements for creating SGT mappings
+on PAN-OS.
+
+See ERS SDK page at: https://ise:9060/ers/sdk
+'''
+
+from collections import defaultdict
+import inspect
+import logging
+import pprint
+import xml.etree.ElementTree as etree
+
+from . import DEBUG1, DEBUG2, DEBUG3
+
+try:
+    import requests
+except ImportError:
+    raise ValueError('Install requests library: '
+                     'http://docs.python-requests.org/')
+
+# https://github.com/shazow/urllib3/issues/655
+# Requests treats None as forever
+_None = object()
+
+
+class IseErsRequest:
+    def __init__(self, name=None):
+        self.name = name
+        # python-requests
+        self.response = None
+        self.status_code = None
+        self.reason = None
+        self.headers = None
+        self.encoding = None
+        self.content = None
+        self.text = None
+        #
+        self.xml_root = None
+        self.obj = None
+
+    def raise_for_status(self):
+        if self.response is not None:
+            try:
+                self.response.raise_for_status()
+            except requests.exceptions.HTTPError as e:
+                raise IseErsError(e)
+
+
+class IseErsError(Exception):
+    pass
+
+
+class IseErs:
+    def __init__(self,
+                 hostname=None,
+                 username=None,
+                 password=None,
+                 verify=None,
+                 timeout=_None):
+        if hostname is None:
+            raise IseErsError('no hostname')
+        if username is None:
+            raise IseErsError('no username')
+        if password is None:
+            raise IseErsError('no password')
+
+        self._log = logging.getLogger(__name__).log
+        self.verify = verify
+        if self.verify is False:
+            requests.packages.urllib3.disable_warnings()
+        self.timeout = timeout
+        self._log(DEBUG2, 'timeout: %s', repr(timeout))
+        self.uri = 'https://' + hostname + ':9060'
+        self.auth = requests.auth.HTTPBasicAuth(username, password)
+
+    def _request(self,
+                 uri,
+                 headers):
+
+        kwargs = {}
+        if self.verify is not None:
+            kwargs['verify'] = self.verify
+        if self.timeout is not _None:
+            kwargs['timeout'] = self.timeout
+
+        try:
+            r = requests.get(url=uri,
+                             headers=headers,
+                             auth=self.auth,
+                             **kwargs)
+        except (requests.exceptions.RequestException, ValueError) as e:
+            raise IseErsError(e)
+
+        return r
+
+    def _set_attributes(self, r):
+        x = IseErsRequest(inspect.stack()[1][3])
+        # http://docs.python-requests.org/en/master/api/#requests.Response
+        x.response = r
+        x.status_code = r.status_code
+        x.reason = r.reason
+        x.headers = r.headers
+        x.encoding = r.encoding
+        self._log(DEBUG2, r.encoding)
+        self._log(DEBUG2, r.request.headers)  # XXX authorization header
+        self._log(DEBUG2, r.headers)
+        x.content = r.content  # bytes
+        x.text = r.text  # Unicode
+        self._log(DEBUG3, r.text)
+        try:
+            x.xml_root = etree.fromstring(r.content)
+        except etree.ParseError as e:
+            self._log(DEBUG1, 'ElementTree.fromstring ParseError: %s', e)
+
+        if x.xml_root is not None:
+            self._log(DEBUG1, 'root tag: %s', x.xml_root.tag)
+            if x.xml_root.tag == '{ers.ise.cisco.com}ersResponse':
+                message = x.xml_root.find('messages/message')
+                if message is not None:
+                    x.obj = {}
+                    x.obj['error'] = {}
+                    for k in ['type', 'code']:
+                        if k in message.attrib:
+                            x.obj['error'][k] = message.attrib[k]
+                    title = message.findall('title')
+                    if title is not None:
+                        x.obj['error']['title'] = []
+                        for elem in title:
+                            x.obj['error']['title'].append(elem.text)
+
+                    self._log(DEBUG2, x.obj)
+
+        return x
+
+    def sgts_ips_map(self):
+        r = self.sgt()
+        r.raise_for_status()
+        if 'sgt' not in r.obj:
+            raise IseErsError('no response data for sgt()')
+        _sgt = r.obj['sgt']
+
+        r = self.sgmapping()
+        r.raise_for_status()
+        if 'sgmapping' not in r.obj:
+            raise IseErsError('no response data for sgmapping()')
+        _sgmapping = r.obj['sgmapping']
+
+        _sgt_name_desc_map = {}
+        _sgt_id_name_map = {}
+        _sgts_ips_map = {}
+        for x in _sgt:
+            _sgt_name_desc_map[x['name']] = x['description']
+            _sgt_id_name_map[x['id']] = x['name']
+            _sgts_ips_map[x['name']] = []
+
+        self._log(DEBUG2, pprint.pformat(_sgt_name_desc_map))
+        self._log(DEBUG2, pprint.pformat(_sgt_id_name_map))
+
+        for x in _sgmapping:
+            r = self.sgmapping(id=x['id'])
+            r.raise_for_status()
+            if 'sgmapping_id' not in r.obj:
+                raise IseErsError('no response data for sgmapping(%s)' %
+                                  x['id'])
+            _sgmapping_id = r.obj['sgmapping_id']
+            if 'hostIp' in _sgmapping_id:
+                if _sgmapping_id['sgt'] not in _sgt_id_name_map:
+                    pass  # XXX refresh _sgt_id_name_map
+                else:
+                    _sgts_ips_map[_sgt_id_name_map[_sgmapping_id['sgt']]].\
+                        append(_sgmapping_id['hostIp'])
+
+        self._log(DEBUG2, pprint.pformat(_sgts_ips_map))
+
+        d = defaultdict(list)
+        [d[v].append(k) for k in _sgts_ips_map for v in _sgts_ips_map[k]]
+
+        self.sgt_name_desc_map = _sgt_name_desc_map
+        self.sgts_ips_map = _sgts_ips_map
+        self.ips_sgts_map = dict(d)
+
+        return self.sgt_name_desc_map, self.sgts_ips_map, self.ips_sgts_map
+
+    def sgt(self,
+            id=None):
+        '''Security Groups:
+        Get-By-Id
+        Get-All
+        '''
+
+        headers = {
+            'accept':
+            'application/vnd.com.cisco.ise.trustsec.sgt.1.0+xml'
+        }
+        path = '/ers/config/sgt'
+        if id is not None:
+            path += '/' + str(id)
+        uri = self.uri + path
+
+        r = self._request(uri=uri, headers=headers)
+        x = self._set_attributes(r)
+
+        if x.xml_root is not None:
+            rk = 'sgt'  # root key
+            if x.xml_root.tag == '{ers.ise.cisco.com}searchResult':
+                x.obj = {}
+                x.obj[rk] = []
+                for elem in x.xml_root.findall('resources/resource'):
+                    for k in ['name', 'id', 'description']:
+                        if k not in elem.attrib:
+                            raise IseErsError('missing attribute \"%s\": %s' %
+                                              (k, elem.attrib))
+                    x.obj[rk].append(elem.attrib)
+
+            elif x.xml_root.tag == '{trustsec.ers.ise.cisco.com}sgt':
+                rk = 'sgt_id'
+                x.obj = {}
+                x.obj[rk] = {}
+                for k in ['id', 'name', 'description']:
+                    if k not in x.xml_root.attrib:
+                        raise IseErsError('missing attribute \"%s\": %s' %
+                                          (k, elem.attrib))
+                    else:
+                        x.obj[rk][k] = x.xml_root.attrib[k]
+                    for elem in x.xml_root.findall('*'):
+                        x.obj[rk][elem.tag] = elem.text
+
+            self._log(DEBUG2, pprint.pformat(x.obj))
+
+        return x
+
+    def sgmapping(self,
+                  id=None):
+        '''IP To SGT Mapping:
+        Get-All
+        Get-By-Id
+        '''
+
+        headers = {
+            'accept':
+            'application/vnd.com.cisco.ise.trustsec.sgmapping.1.0+xml'
+        }
+        path = '/ers/config/sgmapping'
+        if id is not None:
+            path += '/' + str(id)
+        uri = self.uri + path
+
+        r = self._request(uri=uri, headers=headers)
+        x = self._set_attributes(r)
+
+        if x.xml_root is not None:
+            if x.xml_root.tag == '{ers.ise.cisco.com}searchResult':
+                rk = 'sgmapping'
+                x.obj = {}
+                x.obj[rk] = []
+                for elem in x.xml_root.findall('resources/resource'):
+                    for k in ['name', 'id']:
+                        if k not in elem.attrib:
+                            raise IseErsError('missing attribute \"%s\": %s' %
+                                              (k, elem.attrib))
+                    x.obj[rk].append(elem.attrib)
+
+            elif x.xml_root.tag == '{trustsec.ers.ise.cisco.com}sgMapping':
+                rk = 'sgmapping_id'
+                x.obj = {}
+                x.obj[rk] = {}
+                for elem in x.xml_root.findall('*'):
+                    x.obj[rk][elem.tag] = elem.text
+
+            self._log(DEBUG2, pprint.pformat(x.obj))
+
+        return x


### PR DESCRIPTION
Add experimental miner for IP to SGT (Security Group Tag) mappings
from Cisco Identity Services Engine (ISE) using ERS (External RESTful
Services) API.

Adds ciscoise.yml with 2 prototypes:

  ers_sgt: miner using class minemeld.ft.ciscoise.ErsSgt.  Config
  variables are:

    hostname: ISE hostname
    username: ERS API username (in ISE admin group ERS Operator)
    password: ERS API password
    verify_cert: HTTP Requests verify cert
    timeout: HTTP Requests timeout

    NOTE: These can be specified in the prototype config or a side config.

    prefix: SGT prefix (default ise_sgt)

  sgt_dag: output node using class minemeld.ft.dag.DagPusher to push
  IP to SGT mappings to PAN-OS devices via DAG (registered-ip).

minemeld.ft.dag.DagPusher has been modified to handle attributes of
type list for one to many IP to SGT cases.

Sample registered-ip objects:

  admin@PA-200> show object registered-ip all

  registered IP                             Tags
  ----------------------------------------  -----------------

  172.25.1.1
                                           "mmld_ise_sgt_Contractors"
                                           "mmld_pushed"

  10.0.0.1
                                           "mmld_ise_sgt_BYOD"
                                           "mmld_ise_sgt_Developers"
                                           "mmld_ise_sgt_Employees"
                                           "mmld_pushed"

  Total: 2 registered addresses
  *: received from user-id agent  #: persistent