### PR TITLE
Improvements on #90

### DIFF
--- a/minemeld/flask/__init__.py
+++ b/minemeld/flask/__init__.py
@@ -277,6 +277,8 @@ try:
     from . import taxiicollmgmt  # noqa
     from . import taxiipoll  # noqa
 
+    configapi.init_app(app)
+
 except ImportError:
     LOG.exception("redis is needed for feed and config entrypoints")
 
@@ -341,5 +343,3 @@ def app_init():
         app.logger.setLevel(logging.DEBUG)
     else:
         app.logger.setLevel(logging.INFO)
-
-    configapi.init_app(app)

--- a/minemeld/flask/aaaapi.py
+++ b/minemeld/flask/aaaapi.py
@@ -137,7 +137,7 @@ def delete_user(subsystem, username):
     if subsystem is None:
         return jsonify(error='Invalid subsystem'), 400
 
-    with config.lock():    
+    with config.lock():
         users_db = config.get(subsystem.authdb)
         if not users_db.path:
             return jsonify(error='Users database not available')

--- a/minemeld/flask/config.py
+++ b/minemeld/flask/config.py
@@ -35,6 +35,7 @@ _AUTH_DBS = {
     'FEEDS_USERS_DB': 'feeds.htpasswd'
 }
 
+
 def get(key, default=None):
     try:
         result = CONFIG[key]
@@ -76,12 +77,12 @@ class APIConfigDict(object):
     def set(self, key, value):
         curvalues = get(self.attribute, {})
         curvalues[key] = value
-        store(self.filename, { self.attribute: curvalues })
+        store(self.filename, {self.attribute: curvalues})
 
     def delete(self, key):
         curvalues = get(self.attribute, {})
         curvalues.pop(key, None)
-        store(self.filename, { self.attribute: curvalues })
+        store(self.filename, {self.attribute: curvalues})
 
     def value(self):
         return get(self.attribute, {})
@@ -199,7 +200,7 @@ def init():
     # init global vars
     API_CONFIG_PATH = os.path.join(config_path, 'api')
     API_CONFIG_LOCK = filelock.FileLock(
-        os.path.join(API_CONFIG_PATH, 'config.lock')
+        os.environ.get('API_CONFIG_LOCK', '/var/run/minemeld/api-config.lock')
     )
 
     _load_config(config_path)

--- a/minemeld/flask/feedredis.py
+++ b/minemeld/flask/feedredis.py
@@ -24,10 +24,8 @@ from flask import stream_with_context
 import flask.ext.login
 
 from . import app
-from . import aaa
 from . import SR
 from . import MMMaster
-from . import config
 
 LOG = logging.getLogger(__name__)
 FEED_INTERVAL = 100

--- a/minemeld/flask/taxiidiscovery.py
+++ b/minemeld/flask/taxiidiscovery.py
@@ -25,7 +25,7 @@ import flask.ext.login
 
 from . import app
 from . import config
-from .taxiiutils import taxii_check, taxii_make_response
+from .taxiiutils import get_taxii_feeds, taxii_check, taxii_make_response
 
 LOG = logging.getLogger(__name__)
 
@@ -51,6 +51,14 @@ _SERVICE_INSTANCES = [
 @flask.ext.login.login_required
 @taxii_check
 def taxii_discovery_service():
+    taxii_feeds = get_taxii_feeds()
+    authorized = next(
+        (tf for tf in taxii_feeds if flask.ext.login.current_user.check_feed(tf)),
+        None
+    )
+    if authorized is None:
+        return 'Unauthorized', 401
+
     server_host = config.get('TAXII_HOST', None)
     if server_host is None:
         server_host = request.headers.get('Host', None)

--- a/tests/feeds.htpasswd
+++ b/tests/feeds.htpasswd
@@ -1,0 +1,2 @@
+user1:$apr1$SdhtTFdb$br1vVDVDr3r/ZYTo0aj.L0
+guest:$apr1$fUbzwJlK$tXcBNLcN8zhXNGjgB7M6./

--- a/tests/test_flask_aaa.py
+++ b/tests/test_flask_aaa.py
@@ -1,0 +1,1394 @@
+#  Copyright 2016 Palo Alto Networks, Inc
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""FT autofocus tests
+
+Unit tests for minemeld.ft.autofocus
+"""
+
+import gevent.monkey
+gevent.monkey.patch_all(thread=False, select=False)
+
+import unittest
+import mock
+import shutil
+import logging
+import os
+import os.path
+import base64
+import passlib.apache
+import xmltodict
+
+import minemeld.flask
+import minemeld.flask.feedredis
+
+LOG = logging.getLogger(__name__)
+MYDIR = os.path.dirname(__file__)
+TAXII_POLL_REQUEST = """<taxii_11:Poll_Request 
+    xmlns:taxii_11="http://taxii.mitre.org/messages/taxii_xml_binding-1.1"
+    message_id="42158"
+    collection_name="%s">
+    <taxii_11:Exclusive_Begin_Timestamp>2014-12-19T00:00:00Z</taxii_11:Exclusive_Begin_Timestamp>
+    <taxii_11:Inclusive_End_Timestamp>2014-12-19T12:00:00Z</taxii_11:Inclusive_End_Timestamp>
+    <taxii_11:Poll_Parameters allow_asynch="false">
+        <taxii_11:Response_Type>FULL</taxii_11:Response_Type>
+    </taxii_11:Poll_Parameters>
+</taxii_11:Poll_Request>"""
+
+
+def _authorization_header(username, password):
+    return 'Basic '+base64.b64encode(username+':'+password)
+
+
+class MineMeldFlaskAAATests(unittest.TestCase):
+    def setUp(self):
+        try:
+            shutil.rmtree('./api')
+        except OSError:
+            pass
+
+        os.mkdir('api')
+
+        minemeld.flask.app.config.update(
+            DEBUG=True
+        )
+        self.app = minemeld.flask.app.test_client()
+
+    def tearDown(self):
+        try:
+            shutil.rmtree('./api')
+        except OSError:
+            pass
+
+    def _taxii_discovery_request(self, username=None, password=None):
+        headers = {
+            'X-TAXII-Content-Type': 'urn:taxii.mitre.org:message:xml:1.1',
+            'X-TAXII-Protocol': 'urn:taxii.mitre.org:protocol:http:1.0',
+            'X-TAXII-Services': 'urn:taxii.mitre.org:services:1.1'
+        }
+        if username is not None:
+            headers['Authorization'] = _authorization_header(username, password)
+        resp = self.app.post(
+            '/taxii-discovery-service',
+            headers=headers,
+            data='<Discovery_Request xmlns="http://taxii.mitre.org/messages/taxii_xml_binding-1.1" message_id="1"/>'
+        )
+
+        return resp
+
+    def _taxii_collection_request(self, username=None, password=None):
+        headers = {
+            'X-TAXII-Content-Type': 'urn:taxii.mitre.org:message:xml:1.1',
+            'X-TAXII-Protocol': 'urn:taxii.mitre.org:protocol:http:1.0',
+            'X-TAXII-Services': 'urn:taxii.mitre.org:services:1.1'
+        }
+        if username is not None:
+            headers['Authorization'] = _authorization_header(username, password)
+        resp = self.app.post(
+            '/taxii-collection-management-service',
+            headers=headers,
+            data='<taxii_11:Collection_Information_Request xmlns:taxii_11="http://taxii.mitre.org/messages/taxii_xml_binding-1.1" message_id="26300"/>'
+        )
+
+        return resp
+
+    def _taxii_poll_request(self, collection, username=None, password=None):
+        headers = {
+            'X-TAXII-Content-Type': 'urn:taxii.mitre.org:message:xml:1.1',
+            'X-TAXII-Protocol': 'urn:taxii.mitre.org:protocol:http:1.0',
+            'X-TAXII-Services': 'urn:taxii.mitre.org:services:1.1'
+        }
+        if username is not None:
+            headers['Authorization'] = _authorization_header(username, password)
+        resp = self.app.post(
+            '/taxii-poll-service',
+            headers=headers,
+            data=TAXII_POLL_REQUEST % collection
+        )
+
+        return resp        
+
+    def _num_collections(self, resp):
+        ans = xmltodict.parse(resp.data)
+
+        collections = ans['taxii_11:Collection_Information_Response']['taxii_11:Collection']
+        if isinstance(collections, list):
+            return len(collections)
+        return 1
+
+    @mock.patch.dict('minemeld.flask.os.environ', {
+        'MM_CONFIG': '.',
+        'API_CONFIG_LOCK': os.path.join('.', 'api-config.lock'),
+    })
+    @mock.patch('minemeld.flask.config.init')
+    @mock.patch('minemeld.flask.config.get')
+    @mock.patch('minemeld.flask.feedredis.MMMaster')
+    def test_feeds_auth_disabled(self, mmmastermock, configmock, configinitmock):
+        _config_attrs = {
+            'API_AUTH_ENABLED': True,
+            'USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'wsgi.htpasswd')),
+            'FEEDS_USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'feeds.htpasswd')),
+            'FEEDS_AUTH_ENABLED': False
+        }
+
+        def _config_get(attribute, default=None):
+            if attribute in _config_attrs:
+                return _config_attrs[attribute]
+            return default
+
+        configmock.configure_mock(side_effect=_config_get)
+
+        mmmastermock.status.return_value = {
+            'mbus:slave:feed1': {
+                'class': 'minemeld.ft.redis.RedisSet'
+            }
+        }
+
+        resp = self.app.get('/feeds/feed1')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('guest', 'guest')
+        })
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('user1', 'password1')
+        })
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('admin', 'password')
+        })
+        self.assertEqual(resp.status_code, 200)
+
+    @mock.patch.dict('minemeld.flask.os.environ', {
+        'MM_CONFIG': '.',
+        'API_CONFIG_LOCK': os.path.join('.', 'api-config.lock'),
+    })
+    @mock.patch('minemeld.flask.config.init')
+    @mock.patch('minemeld.flask.config.get')
+    @mock.patch('minemeld.flask.feedredis.MMMaster')
+    def test_feeds_single_tag(self, mmmastermock, configmock, configinitmock):
+        _config_attrs = {
+            'API_AUTH_ENABLED': True,
+            'USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'wsgi.htpasswd')),
+            'FEEDS_USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'feeds.htpasswd')),
+            'FEEDS_AUTH_ENABLED': True,
+            'FEEDS_USERS_ATTRS': {
+                'guest': {
+                    'tags': ['open']
+                },
+                'user1': {
+                    'tags': ['confidential']
+                }
+            },
+            'FEEDS_ATTRS': {
+                'feed1': {
+                    'tags': ['confidential']
+                }
+            }
+        }
+
+        def _config_get(attribute, default=None):
+            if attribute in _config_attrs:
+                return _config_attrs[attribute]
+            return default
+
+        configmock.configure_mock(side_effect=_config_get)
+
+        mmmastermock.status.return_value = {
+            'mbus:slave:feed1': {
+                'class': 'minemeld.ft.redis.RedisSet'
+            }
+        }
+
+        resp = self.app.get('/feeds/feed1')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('guest', 'guest')
+        })
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('user1', 'password1')
+        })
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('admin', 'password')
+        })
+        self.assertEqual(resp.status_code, 200)
+
+    @mock.patch.dict('minemeld.flask.os.environ', {
+        'MM_CONFIG': '.',
+        'API_CONFIG_LOCK': os.path.join('.', 'api-config.lock'),
+    })
+    @mock.patch('minemeld.flask.config.init')
+    @mock.patch('minemeld.flask.config.get')
+    @mock.patch('minemeld.flask.feedredis.MMMaster')
+    def test_feeds_two_tags(self, mmmastermock, configmock, configinitmock):
+        _config_attrs = {
+            'API_AUTH_ENABLED': True,
+            'USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'wsgi.htpasswd')),
+            'FEEDS_USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'feeds.htpasswd')),
+            'FEEDS_AUTH_ENABLED': True,
+            'FEEDS_USERS_ATTRS': {
+                'guest': {
+                    'tags': ['open']
+                },
+                'user1': {
+                    'tags': ['confidential']
+                }
+            },
+            'FEEDS_ATTRS': {
+                'feed1': {
+                    'tags': ['confidential', 'open']
+                }
+            }
+        }
+
+        def _config_get(attribute, default=None):
+            if attribute in _config_attrs:
+                return _config_attrs[attribute]
+            return default
+
+        configmock.configure_mock(side_effect=_config_get)
+
+        mmmastermock.status.return_value = {
+            'mbus:slave:feed1': {
+                'class': 'minemeld.ft.redis.RedisSet'
+            }
+        }
+
+        resp = self.app.get('/feeds/feed1')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('guest', 'guest')
+        })
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('user1', 'password1')
+        })
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('admin', 'password')
+        })
+        self.assertEqual(resp.status_code, 200)
+
+    @mock.patch.dict('minemeld.flask.os.environ', {
+        'MM_CONFIG': '.',
+        'API_CONFIG_LOCK': os.path.join('.', 'api-config.lock'),
+    })
+    @mock.patch('minemeld.flask.config.init')
+    @mock.patch('minemeld.flask.config.get')
+    @mock.patch('minemeld.flask.feedredis.MMMaster')
+    def test_feeds_two_and_two(self, mmmastermock, configmock, configinitmock):
+        _config_attrs = {
+            'API_AUTH_ENABLED': True,
+            'USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'wsgi.htpasswd')),
+            'FEEDS_USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'feeds.htpasswd')),
+            'FEEDS_AUTH_ENABLED': True,
+            'FEEDS_USERS_ATTRS': {
+                'guest': {
+                    'tags': ['open', 'test']
+                },
+                'user1': {
+                    'tags': ['confidential']
+                }
+            },
+            'FEEDS_ATTRS': {
+                'feed1': {
+                    'tags': ['confidential', 'open']
+                }
+            }
+        }
+
+        def _config_get(attribute, default=None):
+            if attribute in _config_attrs:
+                return _config_attrs[attribute]
+            return default
+
+        configmock.configure_mock(side_effect=_config_get)
+
+        mmmastermock.status.return_value = {
+            'mbus:slave:feed1': {
+                'class': 'minemeld.ft.redis.RedisSet'
+            }
+        }
+
+        resp = self.app.get('/feeds/feed1')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('guest', 'guest')
+        })
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('user1', 'password1')
+        })
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('admin', 'password')
+        })
+        self.assertEqual(resp.status_code, 200)
+
+    @mock.patch.dict('minemeld.flask.os.environ', {
+        'MM_CONFIG': '.',
+        'API_CONFIG_LOCK': os.path.join('.', 'api-config.lock'),
+    })
+    @mock.patch('minemeld.flask.config.init')
+    @mock.patch('minemeld.flask.config.get')
+    @mock.patch('minemeld.flask.feedredis.MMMaster')
+    def test_feeds_any(self, mmmastermock, configmock, configinitmock):
+        _config_attrs = {
+            'API_AUTH_ENABLED': True,
+            'USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'wsgi.htpasswd')),
+            'FEEDS_USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'feeds.htpasswd')),
+            'FEEDS_AUTH_ENABLED': True,
+            'FEEDS_USERS_ATTRS': {
+                'guest': {
+                    'tags': ['open', 'test']
+                },
+                'user1': {
+                    'tags': ['confidential']
+                }
+            },
+            'FEEDS_ATTRS': {
+                'feed1': {
+                    'tags': ['any']
+                }
+            }
+        }
+
+        def _config_get(attribute, default=None):
+            if attribute in _config_attrs:
+                return _config_attrs[attribute]
+            return default
+
+        configmock.configure_mock(side_effect=_config_get)
+
+        mmmastermock.status.return_value = {
+            'mbus:slave:feed1': {
+                'class': 'minemeld.ft.redis.RedisSet'
+            }
+        }
+
+        resp = self.app.get('/feeds/feed1')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('guest', 'guest')
+        })
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('user1', 'password1')
+        })
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('admin', 'password')
+        })
+        self.assertEqual(resp.status_code, 200)
+
+    @mock.patch.dict('minemeld.flask.os.environ', {
+        'MM_CONFIG': '.',
+        'API_CONFIG_LOCK': os.path.join('.', 'api-config.lock'),
+    })
+    @mock.patch('minemeld.flask.config.init')
+    @mock.patch('minemeld.flask.config.get')
+    @mock.patch('minemeld.flask.feedredis.MMMaster')
+    def test_feeds_anonymous(self, mmmastermock, configmock, configinitmock):
+        _config_attrs = {
+            'API_AUTH_ENABLED': True,
+            'USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'wsgi.htpasswd')),
+            'FEEDS_USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'feeds.htpasswd')),
+            'FEEDS_AUTH_ENABLED': True,
+            'FEEDS_USERS_ATTRS': {
+                'guest': {
+                    'tags': ['open', 'test']
+                },
+                'user1': {
+                    'tags': ['confidential']
+                }
+            },
+            'FEEDS_ATTRS': {
+                'feed1': {
+                    'tags': ['anonymous', 'confidential']
+                }
+            }
+        }
+
+        def _config_get(attribute, default=None):
+            if attribute in _config_attrs:
+                return _config_attrs[attribute]
+            return default
+
+        configmock.configure_mock(side_effect=_config_get)
+
+        mmmastermock.status.return_value = {
+            'mbus:slave:feed1': {
+                'class': 'minemeld.ft.redis.RedisSet'
+            }
+        }
+
+        resp = self.app.get('/feeds/feed1')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('guest', 'guest')
+        })
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('user1', 'password1')
+        })
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('admin', 'password')
+        })
+        self.assertEqual(resp.status_code, 200)
+
+    @mock.patch.dict('minemeld.flask.os.environ', {
+        'MM_CONFIG': '.',
+        'API_CONFIG_LOCK': os.path.join('.', 'api-config.lock'),
+    })
+    @mock.patch('minemeld.flask.config.init')
+    @mock.patch('minemeld.flask.config.get')
+    @mock.patch('minemeld.flask.feedredis.MMMaster')
+    def test_feeds_anonymous_2(self, mmmastermock, configmock, configinitmock):
+        _config_attrs = {
+            'API_AUTH_ENABLED': True,
+            'USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'wsgi.htpasswd')),
+            'FEEDS_USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'feeds.htpasswd')),
+            'FEEDS_AUTH_ENABLED': True,
+            'FEEDS_USERS_ATTRS': {
+                'guest': {
+                    'tags': ['open', 'test']
+                },
+                'user1': {
+                    'tags': ['confidential']
+                }
+            },
+            'FEEDS_ATTRS': {
+                'feed1': {
+                    'tags': ['anonymous']
+                }
+            }
+        }
+
+        def _config_get(attribute, default=None):
+            if attribute in _config_attrs:
+                return _config_attrs[attribute]
+            return default
+
+        configmock.configure_mock(side_effect=_config_get)
+
+        mmmastermock.status.return_value = {
+            'mbus:slave:feed1': {
+                'class': 'minemeld.ft.redis.RedisSet'
+            }
+        }
+
+        resp = self.app.get('/feeds/feed1')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('guest', 'guest')
+        })
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('user1', 'password1')
+        })
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('admin', 'password')
+        })
+        self.assertEqual(resp.status_code, 200)
+
+    @mock.patch.dict('minemeld.flask.os.environ', {
+        'MM_CONFIG': '.',
+        'API_CONFIG_LOCK': os.path.join('.', 'api-config.lock'),
+    })
+    @mock.patch('minemeld.flask.config.init')
+    @mock.patch('minemeld.flask.config.get')
+    @mock.patch('minemeld.flask.feedredis.MMMaster')
+    def test_feeds_no_tags(self, mmmastermock, configmock, configinitmock):
+        _config_attrs = {
+            'API_AUTH_ENABLED': True,
+            'USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'wsgi.htpasswd')),
+            'FEEDS_USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'feeds.htpasswd')),
+            'FEEDS_AUTH_ENABLED': True,
+            'FEEDS_USERS_ATTRS': {
+                'guest': {
+                    'tags': ['open', 'test']
+                },
+                'user1': {
+                    'tags': ['confidential']
+                }
+            },
+            'FEEDS_ATTRS': {}
+        }
+
+        def _config_get(attribute, default=None):
+            if attribute in _config_attrs:
+                return _config_attrs[attribute]
+            return default
+
+        configmock.configure_mock(side_effect=_config_get)
+
+        mmmastermock.status.return_value = {
+            'mbus:slave:feed1': {
+                'class': 'minemeld.ft.redis.RedisSet'
+            }
+        }
+
+        resp = self.app.get('/feeds/feed1')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('guest', 'guest')
+        })
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('user1', 'password1')
+        })
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('admin', 'password')
+        })
+        self.assertEqual(resp.status_code, 200)
+
+    @mock.patch.dict('minemeld.flask.os.environ', {
+        'MM_CONFIG': '.',
+        'API_CONFIG_LOCK': os.path.join('.', 'api-config.lock'),
+    })
+    @mock.patch('minemeld.flask.config.init')
+    @mock.patch('minemeld.flask.config.get')
+    @mock.patch('minemeld.flask.feedredis.MMMaster')
+    def test_feeds_no_user_tags(self, mmmastermock, configmock, configinitmock):
+        _config_attrs = {
+            'API_AUTH_ENABLED': True,
+            'USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'wsgi.htpasswd')),
+            'FEEDS_USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'feeds.htpasswd')),
+            'FEEDS_AUTH_ENABLED': True,
+            'FEEDS_USERS_ATTRS': {
+                'guest': {
+                    'tags': ['open', 'test']
+                }
+            },
+            'FEEDS_ATTRS': {
+                'feed1': {
+                    'tags': ['confidential']
+                }
+            }
+        }
+
+        def _config_get(attribute, default=None):
+            if attribute in _config_attrs:
+                return _config_attrs[attribute]
+            return default
+
+        configmock.configure_mock(side_effect=_config_get)
+
+        mmmastermock.status.return_value = {
+            'mbus:slave:feed1': {
+                'class': 'minemeld.ft.redis.RedisSet'
+            }
+        }
+
+        resp = self.app.get('/feeds/feed1')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('guest', 'guest')
+        })
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('user1', 'password1')
+        })
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': _authorization_header('admin', 'password')
+        })
+        self.assertEqual(resp.status_code, 200)
+
+    @mock.patch.dict('minemeld.flask.os.environ', {
+        'MM_CONFIG': '.',
+        'API_CONFIG_LOCK': os.path.join('.', 'api-config.lock'),
+    })
+    @mock.patch('minemeld.flask.config.init')
+    @mock.patch('minemeld.flask.config.get')
+    @mock.patch('minemeld.flask.feedredis.MMMaster')
+    def test_feeds_malformed(self, mmmastermock, configmock, configinitmock):
+        _config_attrs = {
+            'API_AUTH_ENABLED': True,
+            'USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'wsgi.htpasswd')),
+            'FEEDS_USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'feeds.htpasswd')),
+            'FEEDS_AUTH_ENABLED': True,
+            'FEEDS_USERS_ATTRS': {
+                'guest': {
+                    'tags': ['open', 'test']
+                }
+            },
+            'FEEDS_ATTRS': {
+                'feed1': {
+                    'tags': ['confidential']
+                }
+            }
+        }
+
+        def _config_get(attribute, default=None):
+            if attribute in _config_attrs:
+                return _config_attrs[attribute]
+            return default
+
+        configmock.configure_mock(side_effect=_config_get)
+
+        mmmastermock.status.return_value = {
+            'mbus:slave:feed1': {
+                'class': 'minemeld.ft.redis.RedisSet'
+            }
+        }
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': 'invalid authorization'
+        })
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': 'Basic YWJjZGVmCg'
+        })
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self.app.get('/feeds/feed1', headers={
+            'Authorization': 'Basic '+base64.b64encode('invalidauth')
+        })
+        self.assertEqual(resp.status_code, 401)
+
+    @mock.patch.dict('minemeld.flask.os.environ', {
+        'MM_CONFIG': '.',
+        'API_CONFIG_LOCK': os.path.join('.', 'api-config.lock'),
+    })
+    @mock.patch('minemeld.flask.config.init')
+    @mock.patch('minemeld.flask.config.get')
+    @mock.patch('minemeld.flask.taxiidiscovery.get_taxii_feeds', return_value=['feed1'])
+    @mock.patch('minemeld.flask.taxiicollmgmt.get_taxii_feeds', return_value=['feed1'])
+    def test_taxii_auth_disabled(self, gtfmock1, gtfmock2, configmock, configinitmock):
+        _config_attrs = {
+            'API_AUTH_ENABLED': True,
+            'USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'wsgi.htpasswd')),
+            'FEEDS_USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'feeds.htpasswd')),
+            'FEEDS_AUTH_ENABLED': False,
+            'FEEDS_USERS_ATTRS': {
+                'guest': {
+                    'tags': ['open', 'test']
+                },
+                'user1': {
+                    'tags': ['confidential']
+                }
+            },
+            'FEEDS_ATTRS': {
+                'feed1': {
+                    'tags': ['confidential']
+                }
+            }
+        }
+
+        def _config_get(attribute, default=None):
+            if attribute in _config_attrs:
+                return _config_attrs[attribute]
+            return default
+
+        configmock.configure_mock(side_effect=_config_get)
+
+        resp = self._taxii_discovery_request()
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_discovery_request(username='guest', password='guest')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_discovery_request(username='user1', password='password1')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_discovery_request(username='admin', password='password')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_discovery_request(username='user1', password='password2')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_discovery_request(username='admin', password='password1')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_collection_request()
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_collection_request(username='guest', password='guest')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_collection_request(username='user1', password='password1')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_collection_request(username='admin', password='password')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_collection_request(username='user1', password='password2')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_collection_request(username='admin', password='password2')
+        self.assertEqual(resp.status_code, 200)
+
+    @mock.patch.dict('minemeld.flask.os.environ', {
+        'MM_CONFIG': '.',
+        'API_CONFIG_LOCK': os.path.join('.', 'api-config.lock'),
+    })
+    @mock.patch('minemeld.flask.config.init')
+    @mock.patch('minemeld.flask.config.get')
+    @mock.patch('minemeld.flask.taxiidiscovery.get_taxii_feeds', return_value=['feed1', 'feed2'])
+    @mock.patch('minemeld.flask.taxiicollmgmt.get_taxii_feeds', return_value=['feed1', 'feed2'])
+    def test_taxii_services_tag(self, gtfmock1, gtfmock2, configmock, configinitmock):
+        _config_attrs = {
+            'API_AUTH_ENABLED': True,
+            'USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'wsgi.htpasswd')),
+            'FEEDS_USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'feeds.htpasswd')),
+            'FEEDS_AUTH_ENABLED': True,
+            'FEEDS_USERS_ATTRS': {
+                'guest': {
+                    'tags': ['open', 'test']
+                },
+                'user1': {
+                    'tags': ['confidential']
+                }
+            },
+            'FEEDS_ATTRS': {
+                'feed1': {
+                    'tags': ['confidential']
+                },
+                'feed2': {
+                    'tags': ['disabled']
+                }
+            }
+        }
+
+        def _config_get(attribute, default=None):
+            if attribute in _config_attrs:
+                return _config_attrs[attribute]
+            return default
+
+        configmock.configure_mock(side_effect=_config_get)
+
+        resp = self._taxii_discovery_request()
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_discovery_request(username='guest', password='guest')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_discovery_request(username='user1', password='password1')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_discovery_request(username='admin', password='password')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_discovery_request(username='user1', password='password2')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_discovery_request(username='admin', password='password1')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_collection_request()
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_collection_request(username='guest', password='guest')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_collection_request(username='user1', password='password1')
+        self.assertEqual(self._num_collections(resp), 1)
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_collection_request(username='admin', password='password')
+        self.assertEqual(self._num_collections(resp), 2)
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_collection_request(username='user1', password='password2')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_collection_request(username='admin', password='password2')
+        self.assertEqual(resp.status_code, 401)
+
+    @mock.patch.dict('minemeld.flask.os.environ', {
+        'MM_CONFIG': '.',
+        'API_CONFIG_LOCK': os.path.join('.', 'api-config.lock'),
+    })
+    @mock.patch('minemeld.flask.config.init')
+    @mock.patch('minemeld.flask.config.get')
+    @mock.patch('minemeld.flask.taxiidiscovery.get_taxii_feeds', return_value=['feed1', 'feed2'])
+    @mock.patch('minemeld.flask.taxiicollmgmt.get_taxii_feeds', return_value=['feed1', 'feed2'])
+    def test_taxii_anonymous(self, gtfmock1, gtfmock2, configmock, configinitmock):
+        _config_attrs = {
+            'API_AUTH_ENABLED': True,
+            'USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'wsgi.htpasswd')),
+            'FEEDS_USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'feeds.htpasswd')),
+            'FEEDS_AUTH_ENABLED': True,
+            'FEEDS_USERS_ATTRS': {
+                'guest': {
+                    'tags': ['open', 'test']
+                },
+                'user1': {
+                    'tags': ['confidential']
+                }
+            },
+            'FEEDS_ATTRS': {
+                'feed1': {
+                    'tags': ['confidential']
+                },
+                'feed2': {
+                    'tags': ['anonymous']
+                }
+            }
+        }
+
+        def _config_get(attribute, default=None):
+            if attribute in _config_attrs:
+                return _config_attrs[attribute]
+            return default
+
+        configmock.configure_mock(side_effect=_config_get)
+
+        resp = self._taxii_discovery_request()
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_discovery_request(username='guest', password='guest')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_discovery_request(username='user1', password='password1')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_discovery_request(username='admin', password='password')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_discovery_request(username='user1', password='password2')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_discovery_request(username='admin', password='password1')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_collection_request()
+        self.assertEqual(self._num_collections(resp), 1)
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_collection_request(username='guest', password='guest')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_collection_request(username='user1', password='password1')
+        self.assertEqual(self._num_collections(resp), 1)
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_collection_request(username='admin', password='password')
+        self.assertEqual(self._num_collections(resp), 2)
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_collection_request(username='user1', password='password2')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_collection_request(username='admin', password='password2')
+        self.assertEqual(resp.status_code, 401)
+
+    @mock.patch.dict('minemeld.flask.os.environ', {
+        'MM_CONFIG': '.',
+        'API_CONFIG_LOCK': os.path.join('.', 'api-config.lock'),
+    })
+    @mock.patch('minemeld.flask.config.init')
+    @mock.patch('minemeld.flask.config.get')
+    @mock.patch('minemeld.flask.taxiidiscovery.get_taxii_feeds', return_value=['feed1', 'feed2'])
+    @mock.patch('minemeld.flask.taxiicollmgmt.get_taxii_feeds', return_value=['feed1', 'feed2'])
+    def test_taxii_any(self, gtfmock1, gtfmock2, configmock, configinitmock):
+        _config_attrs = {
+            'API_AUTH_ENABLED': True,
+            'USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'wsgi.htpasswd')),
+            'FEEDS_USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'feeds.htpasswd')),
+            'FEEDS_AUTH_ENABLED': True,
+            'FEEDS_USERS_ATTRS': {
+                'guest': {
+                    'tags': ['open', 'test']
+                },
+                'user1': {
+                    'tags': ['confidential']
+                }
+            },
+            'FEEDS_ATTRS': {
+                'feed1': {
+                    'tags': ['confidential']
+                },
+                'feed2': {
+                    'tags': ['any']
+                }
+            }
+        }
+
+        def _config_get(attribute, default=None):
+            if attribute in _config_attrs:
+                return _config_attrs[attribute]
+            return default
+
+        configmock.configure_mock(side_effect=_config_get)
+
+        resp = self._taxii_discovery_request()
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_discovery_request(username='guest', password='guest')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_discovery_request(username='user1', password='password1')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_discovery_request(username='admin', password='password')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_discovery_request(username='user1', password='password2')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_discovery_request(username='admin', password='password1')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_collection_request()
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_collection_request(username='guest', password='guest')
+        self.assertEqual(self._num_collections(resp), 1)
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_collection_request(username='user1', password='password1')
+        self.assertEqual(self._num_collections(resp), 2)
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_collection_request(username='admin', password='password')
+        self.assertEqual(self._num_collections(resp), 2)
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_collection_request(username='user1', password='password2')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_collection_request(username='admin', password='password2')
+        self.assertEqual(resp.status_code, 401)
+
+    @mock.patch.dict('minemeld.flask.os.environ', {
+        'MM_CONFIG': '.',
+        'API_CONFIG_LOCK': os.path.join('.', 'api-config.lock'),
+    })
+    @mock.patch('minemeld.flask.config.init')
+    @mock.patch('minemeld.flask.config.get')
+    @mock.patch('minemeld.flask.taxiidiscovery.get_taxii_feeds', return_value=['feed1', 'feed2'])
+    @mock.patch('minemeld.flask.taxiicollmgmt.get_taxii_feeds', return_value=['feed1', 'feed2'])
+    def test_taxii_any_anonymous(self, gtfmock1, gtfmock2, configmock, configinitmock):
+        _config_attrs = {
+            'API_AUTH_ENABLED': True,
+            'USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'wsgi.htpasswd')),
+            'FEEDS_USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'feeds.htpasswd')),
+            'FEEDS_AUTH_ENABLED': True,
+            'FEEDS_USERS_ATTRS': {
+                'guest': {
+                    'tags': ['open', 'test']
+                },
+                'user1': {
+                    'tags': ['confidential']
+                }
+            },
+            'FEEDS_ATTRS': {
+                'feed1': {
+                    'tags': ['confidential']
+                },
+                'feed2': {
+                    'tags': ['any', 'anonymous']
+                }
+            }
+        }
+
+        def _config_get(attribute, default=None):
+            if attribute in _config_attrs:
+                return _config_attrs[attribute]
+            return default
+
+        configmock.configure_mock(side_effect=_config_get)
+
+        resp = self._taxii_discovery_request()
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_discovery_request(username='guest', password='guest')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_discovery_request(username='user1', password='password1')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_discovery_request(username='admin', password='password')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_discovery_request(username='user1', password='password2')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_discovery_request(username='admin', password='password1')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_collection_request()
+        self.assertEqual(self._num_collections(resp), 1)
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_collection_request(username='guest', password='guest')
+        self.assertEqual(self._num_collections(resp), 1)
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_collection_request(username='user1', password='password1')
+        self.assertEqual(self._num_collections(resp), 2)
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_collection_request(username='admin', password='password')
+        self.assertEqual(self._num_collections(resp), 2)
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_collection_request(username='user1', password='password2')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_collection_request(username='admin', password='password2')
+        self.assertEqual(resp.status_code, 401)
+
+    @mock.patch.dict('minemeld.flask.os.environ', {
+        'MM_CONFIG': '.',
+        'API_CONFIG_LOCK': os.path.join('.', 'api-config.lock'),
+    })
+    @mock.patch('minemeld.flask.config.init')
+    @mock.patch('minemeld.flask.config.get')
+    @mock.patch('minemeld.flask.taxiipoll.get_taxii_feeds', return_value=['feed1', 'feed2'])
+    def test_taxiipoll_single_tag(self, gtfmock, configmock, configinitmock):
+        _config_attrs = {
+            'API_AUTH_ENABLED': True,
+            'USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'wsgi.htpasswd')),
+            'FEEDS_USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'feeds.htpasswd')),
+            'FEEDS_AUTH_ENABLED': True,
+            'FEEDS_USERS_ATTRS': {
+                'guest': {
+                    'tags': ['open']
+                },
+                'user1': {
+                    'tags': ['confidential']
+                }
+            },
+            'FEEDS_ATTRS': {
+                'feed1': {
+                    'tags': ['confidential']
+                }
+            }
+        }
+
+        def _config_get(attribute, default=None):
+            if attribute in _config_attrs:
+                return _config_attrs[attribute]
+            return default
+
+        configmock.configure_mock(side_effect=_config_get)
+
+        resp = self._taxii_poll_request('feed1')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_poll_request('feed1', username='guest', password='guest')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_poll_request('feed1', username='user1', password='password1')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_poll_request('feed1', username='admin', password='password')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_poll_request('feed1', username='user1', password='password2')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_poll_request('feed1', username='admin', password='password1')
+        self.assertEqual(resp.status_code, 401)
+
+    @mock.patch.dict('minemeld.flask.os.environ', {
+        'MM_CONFIG': '.',
+        'API_CONFIG_LOCK': os.path.join('.', 'api-config.lock'),
+    })
+    @mock.patch('minemeld.flask.config.init')
+    @mock.patch('minemeld.flask.config.get')
+    @mock.patch('minemeld.flask.taxiipoll.get_taxii_feeds', return_value=['feed1', 'feed2'])
+    def test_taxiipolll_two_tags(self, gtfmock, configmock, configinitmock):
+        _config_attrs = {
+            'API_AUTH_ENABLED': True,
+            'USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'wsgi.htpasswd')),
+            'FEEDS_USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'feeds.htpasswd')),
+            'FEEDS_AUTH_ENABLED': True,
+            'FEEDS_USERS_ATTRS': {
+                'guest': {
+                    'tags': ['open']
+                },
+                'user1': {
+                    'tags': ['confidential']
+                }
+            },
+            'FEEDS_ATTRS': {
+                'feed1': {
+                    'tags': ['confidential', 'open']
+                }
+            }
+        }
+
+        def _config_get(attribute, default=None):
+            if attribute in _config_attrs:
+                return _config_attrs[attribute]
+            return default
+
+        configmock.configure_mock(side_effect=_config_get)
+
+        resp = self._taxii_poll_request('feed1')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_poll_request('feed1', username='guest', password='guest')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_poll_request('feed1', username='user1', password='password1')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_poll_request('feed1', username='admin', password='password')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_poll_request('feed1', username='user1', password='password2')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_poll_request('feed1', username='admin', password='password1')
+        self.assertEqual(resp.status_code, 401)
+
+    @mock.patch.dict('minemeld.flask.os.environ', {
+        'MM_CONFIG': '.',
+        'API_CONFIG_LOCK': os.path.join('.', 'api-config.lock'),
+    })
+    @mock.patch('minemeld.flask.config.init')
+    @mock.patch('minemeld.flask.config.get')
+    @mock.patch('minemeld.flask.taxiipoll.get_taxii_feeds', return_value=['feed1', 'feed2'])
+    def test_taxiipoll_two_and_two(self, gtfmock, configmock, configinitmock):
+        _config_attrs = {
+            'API_AUTH_ENABLED': True,
+            'USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'wsgi.htpasswd')),
+            'FEEDS_USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'feeds.htpasswd')),
+            'FEEDS_AUTH_ENABLED': True,
+            'FEEDS_USERS_ATTRS': {
+                'guest': {
+                    'tags': ['open', 'test']
+                },
+                'user1': {
+                    'tags': ['confidential']
+                }
+            },
+            'FEEDS_ATTRS': {
+                'feed1': {
+                    'tags': ['confidential', 'open']
+                }
+            }
+        }
+
+        def _config_get(attribute, default=None):
+            if attribute in _config_attrs:
+                return _config_attrs[attribute]
+            return default
+
+        configmock.configure_mock(side_effect=_config_get)
+
+        resp = self._taxii_poll_request('feed1')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_poll_request('feed1', username='guest', password='guest')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_poll_request('feed1', username='user1', password='password1')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_poll_request('feed1', username='admin', password='password')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_poll_request('feed1', username='user1', password='password2')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_poll_request('feed1', username='admin', password='password1')
+        self.assertEqual(resp.status_code, 401)
+
+    @mock.patch.dict('minemeld.flask.os.environ', {
+        'MM_CONFIG': '.',
+        'API_CONFIG_LOCK': os.path.join('.', 'api-config.lock'),
+    })
+    @mock.patch('minemeld.flask.config.init')
+    @mock.patch('minemeld.flask.config.get')
+    @mock.patch('minemeld.flask.taxiipoll.get_taxii_feeds', return_value=['feed1', 'feed2'])
+    def test_taxiipoll_any(self, gtfmock, configmock, configinitmock):
+        _config_attrs = {
+            'API_AUTH_ENABLED': True,
+            'USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'wsgi.htpasswd')),
+            'FEEDS_USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'feeds.htpasswd')),
+            'FEEDS_AUTH_ENABLED': True,
+            'FEEDS_USERS_ATTRS': {
+                'guest': {
+                    'tags': ['open', 'test']
+                },
+                'user1': {
+                    'tags': ['confidential']
+                }
+            },
+            'FEEDS_ATTRS': {
+                'feed1': {
+                    'tags': ['any']
+                }
+            }
+        }
+
+        def _config_get(attribute, default=None):
+            if attribute in _config_attrs:
+                return _config_attrs[attribute]
+            return default
+
+        configmock.configure_mock(side_effect=_config_get)
+
+        resp = self._taxii_poll_request('feed1')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_poll_request('feed1', username='guest', password='guest')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_poll_request('feed1', username='user1', password='password1')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_poll_request('feed1', username='admin', password='password')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_poll_request('feed1', username='user1', password='password2')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_poll_request('feed1', username='admin', password='password1')
+        self.assertEqual(resp.status_code, 401)
+
+    @mock.patch.dict('minemeld.flask.os.environ', {
+        'MM_CONFIG': '.',
+        'API_CONFIG_LOCK': os.path.join('.', 'api-config.lock'),
+    })
+    @mock.patch('minemeld.flask.config.init')
+    @mock.patch('minemeld.flask.config.get')
+    @mock.patch('minemeld.flask.taxiipoll.get_taxii_feeds', return_value=['feed1', 'feed2'])
+    def test_taxiipoll_anonymous(self, gtfmock, configmock, configinitmock):
+        _config_attrs = {
+            'API_AUTH_ENABLED': True,
+            'USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'wsgi.htpasswd')),
+            'FEEDS_USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'feeds.htpasswd')),
+            'FEEDS_AUTH_ENABLED': True,
+            'FEEDS_USERS_ATTRS': {
+                'guest': {
+                    'tags': ['open', 'test']
+                },
+                'user1': {
+                    'tags': ['confidential']
+                }
+            },
+            'FEEDS_ATTRS': {
+                'feed1': {
+                    'tags': ['anonymous', 'confidential']
+                }
+            }
+        }
+
+        def _config_get(attribute, default=None):
+            if attribute in _config_attrs:
+                return _config_attrs[attribute]
+            return default
+
+        configmock.configure_mock(side_effect=_config_get)
+
+        resp = self._taxii_poll_request('feed1')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_poll_request('feed1', username='guest', password='guest')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_poll_request('feed1', username='user1', password='password1')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_poll_request('feed1', username='admin', password='password')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_poll_request('feed1', username='user1', password='password2')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_poll_request('feed1', username='admin', password='password1')
+        self.assertEqual(resp.status_code, 401)
+
+    @mock.patch.dict('minemeld.flask.os.environ', {
+        'MM_CONFIG': '.',
+        'API_CONFIG_LOCK': os.path.join('.', 'api-config.lock'),
+    })
+    @mock.patch('minemeld.flask.config.init')
+    @mock.patch('minemeld.flask.config.get')
+    @mock.patch('minemeld.flask.taxiipoll.get_taxii_feeds', return_value=['feed1', 'feed2'])
+    def test_taxiipoll_anonymous_2(self, gtfmock, configmock, configinitmock):
+        _config_attrs = {
+            'API_AUTH_ENABLED': True,
+            'USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'wsgi.htpasswd')),
+            'FEEDS_USERS_DB': passlib.apache.HtpasswdFile(path=os.path.join(MYDIR, 'feeds.htpasswd')),
+            'FEEDS_AUTH_ENABLED': True,
+            'FEEDS_USERS_ATTRS': {
+                'guest': {
+                    'tags': ['open', 'test']
+                },
+                'user1': {
+                    'tags': ['confidential']
+                }
+            },
+            'FEEDS_ATTRS': {
+                'feed1': {
+                    'tags': ['anonymous']
+                }
+            }
+        }
+
+        def _config_get(attribute, default=None):
+            if attribute in _config_attrs:
+                return _config_attrs[attribute]
+            return default
+
+        configmock.configure_mock(side_effect=_config_get)
+
+        resp = self._taxii_poll_request('feed1')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_poll_request('feed1', username='guest', password='guest')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_poll_request('feed1', username='user1', password='password1')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_poll_request('feed1', username='admin', password='password')
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self._taxii_poll_request('feed1', username='user1', password='password2')
+        self.assertEqual(resp.status_code, 401)
+
+        resp = self._taxii_poll_request('feed1', username='admin', password='password1')
+        self.assertEqual(resp.status_code, 401)

--- a/tests/wsgi.htpasswd
+++ b/tests/wsgi.htpasswd
@@ -1,0 +1,1 @@
+admin:$apr1$pNXvvCp5$c4VXxDzt9waMeAEFRH7p8.

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands = nosetests -a '!slow' -s {posargs}
 
 [testenv:flake8]
 deps = flake8
-commands = flake8 --ignore E402,E226
+commands = flake8 --ignore E402,E226 --max-line-length=100
 
 [testenv:stress]
 basepython = python2.7
@@ -42,3 +42,4 @@ deps = {[testenv:py27]basedeps}
        -r{toxinidir}/requirements.txt
        -r{toxinidir}/requirements-web.txt
 commands = nosetests -s --logging-level=INFO --with-profile --profile-stats-file profile.log -a 'slow' {posargs}
+


### PR DESCRIPTION
## Motivation

Various improvements on MineMeld AAA.

## Modifications

- Authorizations for TAXII collection management and discovery service are now dynamically calculated based on the tags of the existing TAXII Feeds
- by default config lock file is now created under /var/run/minemeld. Since /var/run should be on a tmpfs volume this prevents issue if minemeld instance is not properly shut down. Path can be controlled via *API_CONFIG_LOCK* environment variable
- added unittests for API AAA logic
- fixed an initialization issue in flask
- fixed PEP8 (@kevinsteves). Max line length is now set to 100.

## Result

AAA should be more stable and powerful.

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>