### PR TITLE
Fix for DagPusher

### DIFF
--- a/minemeld/ft/dag.py
+++ b/minemeld/ft/dag.py
@@ -105,13 +105,16 @@ class DevicePusher(gevent.Greenlet):
             "<type>update</type>",
             "<payload>"
         ]
+        persistent = ''
+        if type_ == 'register':
+            persistent = ' persistent="%d"' % (1 if self.persistent else 0)
         message.append('<%s>' % type_)
 
         if addresses is not None and len(addresses) != 0:
             akeys = sorted(addresses.keys())
             for a in akeys:
                 message.append(
-                    '<entry ip="%s" persistent="%d">' % (a, 1 if self.persistent else 0)
+                    '<entry ip="%s"%s>' % (a, persistent)
                 )
 
                 tags = sorted(addresses[a])


### PR DESCRIPTION
Fix from @kevinsteves to remove *persistent* attribute from DAG *unregister* messages.

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>