### PR TITLE
Minor improvements in minemeld.ft.table.Table

### DIFF
--- a/tests/test_ft_autofocus.py
+++ b/tests/test_ft_autofocus.py
@@ -51,7 +51,7 @@ def gevent_event_mock_factory():
     return result
 
 
-class MineMeldYamlFTTests(unittest.TestCase):
+class MineMeldAutofocusFTTests(unittest.TestCase):
     def setUp(self):
         try:
             shutil.rmtree(FTNAME)
@@ -93,7 +93,7 @@ class MineMeldYamlFTTests(unittest.TestCase):
         a.mgmtbus_initialize()
         a.start()
         self.assertEqual(spawnl_mock.call_count, 1)
-        self.assertEqual(spawn_mock.call_count, 2)
+        self.assertEqual(spawn_mock.call_count, 3)
 
         self.assertEqual(a._type_of_indicator('1.1.1.1'), 'IPv4')
         self.assertEqual(a._type_of_indicator('1.1.1.2-1.1.1.5'), 'IPv4')
@@ -103,7 +103,6 @@ class MineMeldYamlFTTests(unittest.TestCase):
         self.assertEqual(a._type_of_indicator('https://www.google.com'), 'URL')
 
         a.stop()
-        a.table.db.close()
 
         a = None
         chassis = None

--- a/tests/test_ft_basepoller.py
+++ b/tests/test_ft_basepoller.py
@@ -208,7 +208,7 @@ class MineMeldFTBasePollerTests(unittest.TestCase):
         a.mgmtbus_initialize()
         a.start()
         self.assertEqual(spawnl_mock.call_count, 1)
-        self.assertEqual(spawn_mock.call_count, 2)
+        self.assertEqual(spawn_mock.call_count, 3)
 
         CUR_LOGICAL_TIME = 1
         a._age_out()
@@ -255,7 +255,7 @@ class MineMeldFTBasePollerTests(unittest.TestCase):
         self.assertEqual(a.length(), 3)
 
         a.stop()
-        a.table.db.close()
+
 
         a = None
         chassis = None
@@ -291,7 +291,7 @@ class MineMeldFTBasePollerTests(unittest.TestCase):
         a.mgmtbus_initialize()
         a.start()
         self.assertEqual(spawnl_mock.call_count, 1)
-        self.assertEqual(spawn_mock.call_count, 2)
+        self.assertEqual(spawn_mock.call_count, 3)
 
         CUR_LOGICAL_TIME = 1
         a._age_out()
@@ -341,7 +341,7 @@ class MineMeldFTBasePollerTests(unittest.TestCase):
         self.assertEqual(a.length(), 0)
 
         a.stop()
-        a.table.db.close()
+
 
         a = None
         chassis = None
@@ -377,7 +377,7 @@ class MineMeldFTBasePollerTests(unittest.TestCase):
         a.mgmtbus_initialize()
         a.start()
         self.assertEqual(spawnl_mock.call_count, 1)
-        self.assertEqual(spawn_mock.call_count, 2)
+        self.assertEqual(spawn_mock.call_count, 3)
 
         CUR_LOGICAL_TIME = 1
         a._age_out()
@@ -427,7 +427,7 @@ class MineMeldFTBasePollerTests(unittest.TestCase):
         self.assertEqual(a.length(), 0)
 
         a.stop()
-        a.table.db.close()
+
 
         a = None
         chassis = None
@@ -463,7 +463,7 @@ class MineMeldFTBasePollerTests(unittest.TestCase):
         a.mgmtbus_initialize()
         a.start()
         self.assertEqual(spawnl_mock.call_count, 1)
-        self.assertEqual(spawn_mock.call_count, 2)
+        self.assertEqual(spawn_mock.call_count, 3)
 
         CUR_LOGICAL_TIME = 1
         a._age_out()
@@ -498,7 +498,7 @@ class MineMeldFTBasePollerTests(unittest.TestCase):
         self.assertEqual(a.length(), 0)
 
         a.stop()
-        a.table.db.close()
+
 
         a = None
         chassis = None
@@ -533,7 +533,7 @@ class MineMeldFTBasePollerTests(unittest.TestCase):
         a.mgmtbus_initialize()
         a.start()
         self.assertEqual(spawnl_mock.call_count, 1)
-        self.assertEqual(spawn_mock.call_count, 2)
+        self.assertEqual(spawn_mock.call_count, 3)
 
         a._actor_queue.put((0, 'age_out'))
         a._actor_queue.put((999, 'age_out'))
@@ -547,7 +547,7 @@ class MineMeldFTBasePollerTests(unittest.TestCase):
         self.assertEqual(um_mock.call_count, 2)
 
         a.stop()
-        a.table.db.close()
+
 
         a = None
         chassis = None

--- a/tests/test_ft_dag.py
+++ b/tests/test_ft_dag.py
@@ -134,7 +134,7 @@ class MineMeldFTDagPusherTests(unittest.TestCase):
         a.mgmtbus_initialize()
         a.start()
         self.assertEqual(spawnl_mock.call_count, 1)
-        self.assertEqual(spawn_mock.call_count, 0)
+        self.assertEqual(spawn_mock.call_count, 1)
 
         # 1st round
         try:
@@ -194,7 +194,6 @@ class MineMeldFTDagPusherTests(unittest.TestCase):
             self.assertEqual(a.device_pushers[i].device, d)
 
         a.stop()
-        a.table.db.close()
 
         a = None
         chassis = None
@@ -238,7 +237,7 @@ class MineMeldFTDagPusherTests(unittest.TestCase):
         a.mgmtbus_initialize()
         a.start()
         self.assertEqual(spawnl_mock.call_count, 1)
-        self.assertEqual(spawn_mock.call_count, 0)
+        self.assertEqual(spawn_mock.call_count, 1)
 
         try:
             a._device_list_monitor()
@@ -282,7 +281,7 @@ class MineMeldFTDagPusherTests(unittest.TestCase):
             self.assertEqual(d.put.call_count, 0)
 
         a.stop()
-        a.table.db.close()
+
 
         a = None
         chassis = None
@@ -326,7 +325,7 @@ class MineMeldFTDagPusherTests(unittest.TestCase):
         a.mgmtbus_initialize()
         a.start()
         self.assertEqual(spawnl_mock.call_count, 1)
-        self.assertEqual(spawn_mock.call_count, 0)
+        self.assertEqual(spawn_mock.call_count, 1)
 
         try:
             a._device_list_monitor()
@@ -348,7 +347,7 @@ class MineMeldFTDagPusherTests(unittest.TestCase):
         self.assertEqual(a.length(), 0)
 
         a.stop()
-        a.table.db.close()
+
 
         a = None
         chassis = None
@@ -392,7 +391,7 @@ class MineMeldFTDagPusherTests(unittest.TestCase):
         a.mgmtbus_initialize()
         a.start()
         self.assertEqual(spawnl_mock.call_count, 1)
-        self.assertEqual(spawn_mock.call_count, 0)
+        self.assertEqual(spawn_mock.call_count, 1)
 
         try:
             a._device_list_monitor()
@@ -436,7 +435,7 @@ class MineMeldFTDagPusherTests(unittest.TestCase):
             self.assertEqual(d.put.call_count, 0)
 
         a.stop()
-        a.table.db.close()
+
 
         a = None
         chassis = None
@@ -480,7 +479,7 @@ class MineMeldFTDagPusherTests(unittest.TestCase):
         a.mgmtbus_initialize()
         a.start()
         self.assertEqual(spawnl_mock.call_count, 1)
-        self.assertEqual(spawn_mock.call_count, 0)
+        self.assertEqual(spawn_mock.call_count, 1)
 
         try:
             a._device_list_monitor()
@@ -524,7 +523,7 @@ class MineMeldFTDagPusherTests(unittest.TestCase):
             self.assertEqual(d.put.call_count, 0)
 
         a.stop()
-        a.table.db.close()
+
 
         a = None
         chassis = None
@@ -536,7 +535,7 @@ class MineMeldFTDagPusherTests(unittest.TestCase):
     @mock.patch.object(pan.xapi, 'PanXapi', side_effect=panos_mock.factory)
     def test_devicepusher_dag_message(self, panxapi_mock):
         RESULT_REG = '<uid-message><version>1.0</version><type>update</type><payload><register><entry ip="192.168.1.1" persistent="0"><tag><member>a</member><member>b</member></tag></entry></register></payload></uid-message>'
-        RESULT_UNREG = '<uid-message><version>1.0</version><type>update</type><payload><unregister><entry ip="192.168.1.1" persistent="0"><tag><member>a</member><member>b</member></tag></entry></unregister></payload></uid-message>'
+        RESULT_UNREG = '<uid-message><version>1.0</version><type>update</type><payload><unregister><entry ip="192.168.1.1"><tag><member>a</member><member>b</member></tag></entry></unregister></payload></uid-message>'
 
         dp = minemeld.ft.dag.DevicePusher(
             {'tag': 'test'},
@@ -563,13 +562,13 @@ class MineMeldFTDagPusherTests(unittest.TestCase):
         )
 
         tags = dp._tags_from_value({'confidence': 49, 'direction': 'inbound'})
-        self.assertEqual(tags, ['mmeld_confidence_low', 'mmeld_direction_inbound'])
+        self.assertEqual(tags, set(['mmeld_confidence_low', 'mmeld_direction_inbound']))
 
         tags = dp._tags_from_value({'confidence': 50})
-        self.assertEqual(tags, ['mmeld_confidence_medium', 'mmeld_direction_unknown'])
+        self.assertEqual(tags, set(['mmeld_confidence_medium', 'mmeld_direction_unknown']))
 
         tags = dp._tags_from_value({'confidence': 75, 'direction': 'outbound'})
-        self.assertEqual(tags, ['mmeld_confidence_high', 'mmeld_direction_outbound'])
+        self.assertEqual(tags, set(['mmeld_confidence_high', 'mmeld_direction_outbound']))
 
     @mock.patch.object(pan.xapi, 'PanXapi', side_effect=panos_mock.factory)
     def test_devicepusher_get_all_registered_ips(self, panxapi_mock):
@@ -622,5 +621,5 @@ class MineMeldFTDagPusherTests(unittest.TestCase):
         )
         self.assertEqual(
             dp.xapi.user_id_calls[1],
-            '<uid-message><version>1.0</version><type>update</type><payload><unregister><entry ip="192.168.1.1" persistent="0"><tag><member>mmeld_confidence_100</member><member>mmeld_pushed</member></tag></entry><entry ip="192.168.1.2" persistent="0"><tag><member>mmeld_confidence_100</member><member>mmeld_test</member></tag></entry></unregister></payload></uid-message>'
+            '<uid-message><version>1.0</version><type>update</type><payload><unregister><entry ip="192.168.1.1"><tag><member>mmeld_confidence_100</member><member>mmeld_pushed</member></tag></entry><entry ip="192.168.1.2"><tag><member>mmeld_confidence_100</member><member>mmeld_test</member></tag></entry></unregister></payload></uid-message>'
         )

--- a/tests/test_ft_ipop.py
+++ b/tests/test_ft_ipop.py
@@ -251,7 +251,7 @@ class MineMeldFTIPOpTests(unittest.TestCase):
         ))
 
         a.stop()
-        a.table.db.close()
+
         a.st.db.close()
         a = None
 
@@ -325,7 +325,7 @@ class MineMeldFTIPOpTests(unittest.TestCase):
         )
 
         a.stop()
-        a.table.db.close()
+
         a.st.db.close()
         a = None
 
@@ -406,7 +406,7 @@ class MineMeldFTIPOpTests(unittest.TestCase):
         )
 
         a.stop()
-        a.table.db.close()
+
         a.st.db.close()
         a = None
 
@@ -513,7 +513,7 @@ class MineMeldFTIPOpTests(unittest.TestCase):
         )
 
         a.stop()
-        a.table.db.close()
+
         a.st.db.close()
         a = None
 
@@ -587,7 +587,7 @@ class MineMeldFTIPOpTests(unittest.TestCase):
         )
 
         a.stop()
-        a.table.db.close()
+
         a.st.db.close()
         a = None
 
@@ -657,7 +657,7 @@ class MineMeldFTIPOpTests(unittest.TestCase):
         )
 
         a.stop()
-        a.table.db.close()
+
         a.st.db.close()
         a = None
 
@@ -761,7 +761,7 @@ class MineMeldFTIPOpTests(unittest.TestCase):
         )
 
         a.stop()
-        a.table.db.close()
+
         a.st.db.close()
         a = None
 
@@ -822,7 +822,7 @@ class MineMeldFTIPOpTests(unittest.TestCase):
         )
 
         a.stop()
-        a.table.db.close()
+
         a.st.db.close()
         a = None
 
@@ -885,7 +885,7 @@ class MineMeldFTIPOpTests(unittest.TestCase):
         )
 
         a.stop()
-        a.table.db.close()
+
         a.st.db.close()
         a = None
 
@@ -957,7 +957,7 @@ class MineMeldFTIPOpTests(unittest.TestCase):
         )
 
         a.stop()
-        a.table.db.close()
+
         a.st.db.close()
         a = None
 
@@ -1026,7 +1026,7 @@ class MineMeldFTIPOpTests(unittest.TestCase):
         )
 
         a.stop()
-        a.table.db.close()
+
         a.st.db.close()
         a = None
 
@@ -1097,7 +1097,7 @@ class MineMeldFTIPOpTests(unittest.TestCase):
         print "TIME: Updated %d intervals in %d" % (num_intervals, (t2-t1-dt))
 
         a.stop()
-        a.table.db.close()
+
         a.st.db.close()
         a = None
 
@@ -1149,6 +1149,6 @@ class MineMeldFTIPOpTests(unittest.TestCase):
         print "TIME: Inserted %d intervals in %d" % (num_intervals, (t2-t1-dt))
 
         a.stop()
-        a.table.db.close()
+
         a.st.db.close()
         a = None

--- a/tests/test_ft_local.py
+++ b/tests/test_ft_local.py
@@ -124,7 +124,7 @@ class MineMeldYamlFTTests(unittest.TestCase):
         a.mgmtbus_initialize()
         a.start()
         self.assertEqual(spawnl_mock.call_count, 1)
-        self.assertEqual(spawn_mock.call_count, 2)
+        self.assertEqual(spawn_mock.call_count, 3)
 
         CUR_LOGICAL_TIME = 1
         a._age_out()
@@ -192,7 +192,6 @@ class MineMeldYamlFTTests(unittest.TestCase):
         self.assertEqual(a.length(), 2)
 
         a.stop()
-        a.table.db.close()
 
         a = None
         chassis = None

--- a/tests/test_ft_op.py
+++ b/tests/test_ft_op.py
@@ -142,7 +142,6 @@ class MineMeldFTOpTests(unittest.TestCase):
         self.assertEqual(pargs[1]['value']['s1$a'], 1)
 
         a.stop()
-        a.table.db.close()
 
         a = None
         chassis = None
@@ -188,7 +187,6 @@ class MineMeldFTOpTests(unittest.TestCase):
         self.assertEqual(pargs[1]['indicator'], 'i')
 
         a.stop()
-        a.table.db.close()
 
         a = None
         chassis = None
@@ -234,7 +232,6 @@ class MineMeldFTOpTests(unittest.TestCase):
         self.assertListEqual(pargs[1]['value']['sources'], ['s1s'])
 
         a.stop()
-        a.table.db.close()
 
         a = None
         chassis = None
@@ -290,7 +287,7 @@ class MineMeldFTOpTests(unittest.TestCase):
         self.assertEqual(pargs[0], 'withdraw')
 
         a.stop()
-        a.table.db.close()
+
 
         a = None
         chassis = None
@@ -349,7 +346,7 @@ class MineMeldFTOpTests(unittest.TestCase):
         self.assertListEqual(pargs[1]['value']['sources'], ['s1s'])
 
         a.stop()
-        a.table.db.close()
+
 
         a = None
         chassis = None
@@ -398,7 +395,7 @@ class MineMeldFTOpTests(unittest.TestCase):
         self.assertEqual(ochannel.publish.call_count, 0)
 
         a.stop()
-        a.table.db.close()
+
 
         a = None
         chassis = None
@@ -455,7 +452,7 @@ class MineMeldFTOpTests(unittest.TestCase):
         self.assertEqual(pargs[1]['indicator'], 'i')
 
         a.stop()
-        a.table.db.close()
+
 
         a = None
         chassis = None
@@ -522,7 +519,7 @@ class MineMeldFTOpTests(unittest.TestCase):
         )
 
         a.stop()
-        a.table.db.close()
+
         a = None
         gc.collect()
 
@@ -602,7 +599,7 @@ class MineMeldFTOpTests(unittest.TestCase):
         )
 
         a.stop()
-        a.table.db.close()
+
         a = None
         gc.collect()
 
@@ -683,6 +680,6 @@ class MineMeldFTOpTests(unittest.TestCase):
         )
 
         a.stop()
-        a.table.db.close()
+
         a = None
         gc.collect()

--- a/tests/test_ft_syslog.py
+++ b/tests/test_ft_syslog.py
@@ -171,9 +171,6 @@ class MineMeldFTSyslogMatcherests(unittest.TestCase):
         )
 
         a.stop()
-        a.table.db.close()
-        a.table_ipv4.db.close()
-        a.table_indicators.db.close()
 
         a = None
         chassis = None
@@ -227,9 +224,6 @@ class MineMeldFTSyslogMatcherests(unittest.TestCase):
         )
 
         a.stop()
-        a.table.db.close()
-        a.table_ipv4.db.close()
-        a.table_indicators.db.close()
 
         a = None
         chassis = None
@@ -273,9 +267,6 @@ class MineMeldFTSyslogMatcherests(unittest.TestCase):
         self.assertEqual(ochannel.publish.call_count, 0)
 
         a.stop()
-        a.table.db.close()
-        a.table_ipv4.db.close()
-        a.table_indicators.db.close()
 
         a = None
         chassis = None
@@ -336,9 +327,6 @@ class MineMeldFTSyslogMatcherests(unittest.TestCase):
         )
 
         a.stop()
-        a.table.db.close()
-        a.table_ipv4.db.close()
-        a.table_indicators.db.close()
 
         a = None
         chassis = None
@@ -393,9 +381,6 @@ class MineMeldFTSyslogMatcherests(unittest.TestCase):
         )
 
         a.stop()
-        a.table.db.close()
-        a.table_ipv4.db.close()
-        a.table_indicators.db.close()
 
         a = None
         chassis = None
@@ -447,9 +432,6 @@ class MineMeldFTSyslogMatcherests(unittest.TestCase):
         self.assertEqual(mock_socket.sendall.call_count, 1)
 
         a.stop()
-        a.table.db.close()
-        a.table_ipv4.db.close()
-        a.table_indicators.db.close()
 
         a = None
         chassis = None
@@ -498,9 +480,6 @@ class MineMeldFTSyslogMatcherests(unittest.TestCase):
         self.assertEqual(mock_socket.sendall.call_count, 1)
 
         a.stop()
-        a.table.db.close()
-        a.table_ipv4.db.close()
-        a.table_indicators.db.close()
 
         a = None
         chassis = None
@@ -558,9 +537,6 @@ class MineMeldFTSyslogMatcherests(unittest.TestCase):
         )
 
         a.stop()
-        a.table.db.close()
-        a.table_ipv4.db.close()
-        a.table_indicators.db.close()
 
         a = None
         chassis = None

--- a/tests/test_ft_table.py
+++ b/tests/test_ft_table.py
@@ -47,14 +47,17 @@ class MineMeldFTTableTests(unittest.TestCase):
     def test_truncate(self):
         table = minemeld.ft.table.Table(TABLENAME)
         table.put('key', {'a': 1})
+        table.close()
         table = None
 
         table = minemeld.ft.table.Table(TABLENAME)
         self.assertEqual(table.num_indicators, 1)
+        table.close()
         table = None
 
         table = minemeld.ft.table.Table(TABLENAME, truncate=True)
         self.assertEqual(table.num_indicators, 0)
+        table.close()
 
     def test_insert(self):
         table = minemeld.ft.table.Table(TABLENAME)
@@ -66,6 +69,7 @@ class MineMeldFTTableTests(unittest.TestCase):
             table.put(key, value)
 
         self.assertEqual(table.num_indicators, NUM_ELEMENTS)
+        table.close()
 
     def test_index_query(self):
         table = minemeld.ft.table.Table(TABLENAME)
@@ -82,6 +86,7 @@ class MineMeldFTTableTests(unittest.TestCase):
             j += 1
 
         self.assertEqual(j, NUM_ELEMENTS)
+        table.close()
 
     def test_query(self):
         table = minemeld.ft.table.Table(TABLENAME)
@@ -97,6 +102,7 @@ class MineMeldFTTableTests(unittest.TestCase):
             j += 1
 
         self.assertEqual(j, NUM_ELEMENTS)
+        table.close()
 
     def test_exists(self):
         table = minemeld.ft.table.Table(TABLENAME)
@@ -113,6 +119,7 @@ class MineMeldFTTableTests(unittest.TestCase):
                 table.exists('i%d' % j),
                 msg="i%d does not exists" % j
             )
+        table.close()
 
     def test_not_exists(self):
         table = minemeld.ft.table.Table(TABLENAME)
@@ -126,6 +133,7 @@ class MineMeldFTTableTests(unittest.TestCase):
         for i in range(NUM_ELEMENTS):
             j = random.randint(NUM_ELEMENTS, 2*NUM_ELEMENTS)
             self.assertFalse(table.exists('i%d' % j))
+        table.close()
 
     def test_update(self):
         table = minemeld.ft.table.Table(TABLENAME)
@@ -143,6 +151,7 @@ class MineMeldFTTableTests(unittest.TestCase):
 
         self.assertEqual(rk, 'k2')
         self.assertEqual(ok, 1)
+        table.close()
 
     @attr('slow')
     def test_random(self):
@@ -202,6 +211,7 @@ class MineMeldFTTableTests(unittest.TestCase):
                 j = j+1
 
         # close table
+        table.close()
         table = None
 
         # reopen
@@ -218,6 +228,8 @@ class MineMeldFTTableTests(unittest.TestCase):
             de = flatdict[j]
             self.assertEqual(de[1]['a'], v['a'])
             j = j+1
+
+        table.close()
 
     @attr('slow')
     def test_write(self):

--- a/tests/test_ft_taxii.py
+++ b/tests/test_ft_taxii.py
@@ -33,6 +33,8 @@ import xmltodict
 import os
 import libtaxii.constants
 import re
+import lz4
+import json
 
 import minemeld.ft.taxii
 import minemeld.ft
@@ -185,10 +187,13 @@ class MineMeldFTTaxiiTests(unittest.TestCase):
         else:
             self.fail(msg='hset not found')
 
-        stixdict = xmltodict.parse(args[2])
-        indicator = stixdict['stix:STIX_Package']['stix:Indicators']['stix:Indicator']
-        cyboxprops = indicator['indicator:Observable']['cybox:Object']['cybox:Properties']
-        self.assertEqual(cyboxprops['AddressObj:Address_Value'], '1.1.1.1')
+        self.assertEqual(args[2].startswith('lz4'), True)
+        stixdict = json.loads(lz4.uncompress(args[2][3:]))
+
+        indicator = stixdict['indicators'][0]
+        cyboxprops = indicator['observable']['object']['properties']
+        self.assertEqual(cyboxprops['address_value'], '1.1.1.1')
+        self.assertEqual(cyboxprops['xsi:type'], 'AddressObjectType')
         SR_mock.reset_mock()
 
         # CIDR
@@ -209,10 +214,13 @@ class MineMeldFTTaxiiTests(unittest.TestCase):
         else:
             self.fail(msg='hset not found')
 
-        stixdict = xmltodict.parse(args[2])
-        indicator = stixdict['stix:STIX_Package']['stix:Indicators']['stix:Indicator']
-        cyboxprops = indicator['indicator:Observable']['cybox:Object']['cybox:Properties']
-        self.assertEqual(cyboxprops['AddressObj:Address_Value'], '1.1.1.0/24')
+        self.assertEqual(args[2].startswith('lz4'), True)
+        stixdict = json.loads(lz4.uncompress(args[2][3:]))
+
+        indicator = stixdict['indicators'][0]
+        cyboxprops = indicator['observable']['object']['properties']
+        self.assertEqual(cyboxprops['address_value'], '1.1.1.0/24')
+        self.assertEqual(cyboxprops['xsi:type'], 'AddressObjectType')
         SR_mock.reset_mock()
 
         # fake range
@@ -233,10 +241,13 @@ class MineMeldFTTaxiiTests(unittest.TestCase):
         else:
             self.fail(msg='hset not found')
 
-        stixdict = xmltodict.parse(args[2])
-        indicator = stixdict['stix:STIX_Package']['stix:Indicators']['stix:Indicator']
-        cyboxprops = indicator['indicator:Observable']['cybox:Object']['cybox:Properties']
-        self.assertEqual(cyboxprops['AddressObj:Address_Value'], '1.1.1.1')
+        self.assertEqual(args[2].startswith('lz4'), True)
+        stixdict = json.loads(lz4.uncompress(args[2][3:]))
+
+        indicator = stixdict['indicators'][0]
+        cyboxprops = indicator['observable']['object']['properties']
+        self.assertEqual(cyboxprops['address_value'], '1.1.1.1')
+        self.assertEqual(cyboxprops['xsi:type'], 'AddressObjectType')
         SR_mock.reset_mock()
 
         # fake range 2
@@ -257,10 +268,13 @@ class MineMeldFTTaxiiTests(unittest.TestCase):
         else:
             self.fail(msg='hset not found')
 
-        stixdict = xmltodict.parse(args[2])
-        indicator = stixdict['stix:STIX_Package']['stix:Indicators']['stix:Indicator']
-        cyboxprops = indicator['indicator:Observable']['cybox:Object']['cybox:Properties']
-        self.assertEqual(cyboxprops['AddressObj:Address_Value'], '1.1.1.0/27')
+        self.assertEqual(args[2].startswith('lz4'), True)
+        stixdict = json.loads(lz4.uncompress(args[2][3:]))
+
+        indicator = stixdict['indicators'][0]
+        cyboxprops = indicator['observable']['object']['properties']
+        self.assertEqual(cyboxprops['address_value'], '1.1.1.0/27')
+        self.assertEqual(cyboxprops['xsi:type'], 'AddressObjectType')
         SR_mock.reset_mock()
 
         # real range
@@ -281,12 +295,16 @@ class MineMeldFTTaxiiTests(unittest.TestCase):
         else:
             self.fail(msg='hset not found')
 
-        stixdict = xmltodict.parse(args[2])
-        indicator = stixdict['stix:STIX_Package']['stix:Indicators']['stix:Indicator']
-        cyboxprops = indicator[0]['indicator:Observable']['cybox:Object']['cybox:Properties']
-        self.assertEqual(cyboxprops['AddressObj:Address_Value'], '1.1.1.0/27')
-        cyboxprops = indicator[1]['indicator:Observable']['cybox:Object']['cybox:Properties']
-        self.assertEqual(cyboxprops['AddressObj:Address_Value'], '1.1.1.32/31')
+        self.assertEqual(args[2].startswith('lz4'), True)
+        stixdict = json.loads(lz4.uncompress(args[2][3:]))
+
+        indicator = stixdict['indicators']
+        cyboxprops = indicator[0]['observable']['object']['properties']
+        self.assertEqual(cyboxprops['address_value'], '1.1.1.0/27')
+        self.assertEqual(cyboxprops['xsi:type'], 'AddressObjectType')
+        cyboxprops = indicator[1]['observable']['object']['properties']
+        self.assertEqual(cyboxprops['address_value'], '1.1.1.32/31')
+        self.assertEqual(cyboxprops['xsi:type'], 'AddressObjectType')
         SR_mock.reset_mock()
 
         b.stop()
@@ -336,10 +354,13 @@ class MineMeldFTTaxiiTests(unittest.TestCase):
         else:
             self.fail(msg='hset not found')
 
-        stixdict = xmltodict.parse(args[2])
-        indicator = stixdict['stix:STIX_Package']['stix:Indicators']['stix:Indicator']
-        cyboxprops = indicator['indicator:Observable']['cybox:Object']['cybox:Properties']
-        self.assertEqual(cyboxprops['DomainNameObj:Value'], 'example.com')
+        self.assertEqual(args[2].startswith('lz4'), True)
+        stixdict = json.loads(lz4.decompress(args[2][3:]))
+
+        indicator = stixdict['indicators'][0]
+        cyboxprops = indicator['observable']['object']['properties']
+        self.assertEqual(cyboxprops['value'], 'example.com')
+        self.assertEqual(cyboxprops['type'], 'FQDN')
         SR_mock.reset_mock()
 
         b.stop()
@@ -389,10 +410,13 @@ class MineMeldFTTaxiiTests(unittest.TestCase):
         else:
             self.fail(msg='hset not found')
 
-        stixdict = xmltodict.parse(args[2])
-        indicator = stixdict['stix:STIX_Package']['stix:Indicators']['stix:Indicator']
-        cyboxprops = indicator['indicator:Observable']['cybox:Object']['cybox:Properties']
-        self.assertEqual(cyboxprops['URIObj:Value'], 'www.example.com/admin.php')
+        self.assertEqual(args[2].startswith('lz4'), True)
+        stixdict = json.loads(lz4.decompress(args[2][3:]))
+
+        indicator = stixdict['indicators'][0]
+        cyboxprops = indicator['observable']['object']['properties']
+        self.assertEqual(cyboxprops['type'], 'URL')
+        self.assertEqual(cyboxprops['value'], 'www.example.com/admin.php')
         SR_mock.reset_mock()
 
         b.stop()
@@ -442,10 +466,13 @@ class MineMeldFTTaxiiTests(unittest.TestCase):
         else:
             self.fail(msg='hset not found')
 
-        stixdict = xmltodict.parse(args[2])
-        indicator = stixdict['stix:STIX_Package']['stix:Indicators']['stix:Indicator']
-        cyboxprops = indicator['indicator:Observable']['cybox:Object']['cybox:Properties']
-        self.assertEqual(cyboxprops['URIObj:Value'], u'\u2603.net/p\xe5th')
+        self.assertEqual(args[2].startswith('lz4'), True)
+        stixdict = json.loads(lz4.decompress(args[2][3:]))
+
+        indicator = stixdict['indicators'][0]
+        cyboxprops = indicator['observable']['object']['properties']
+        self.assertEqual(cyboxprops['type'], 'URL')
+        self.assertEqual(cyboxprops['value'], u'\u2603.net/p\xe5th')
         SR_mock.reset_mock()
 
         b.stop()


### PR DESCRIPTION
Adds iterator context in table query
Adds code to close table in destructor
Adds counter to track lazily deleted index keys

Side-effect: fixed tests

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>