### PR TITLE
Improvements

### DIFF
--- a/minemeld/ft/basepoller.py
+++ b/minemeld/ft/basepoller.py
@@ -131,7 +131,7 @@ class _BPTable_v1(_BaseBPTable):
     def _type_key(self, indicator, itype):
         if itype is None:
             raise RuntimeError('Type None in table with type in key')
-        return '{}::{}'.format(itype, indicator)
+        return u'{}::{}'.format(itype, indicator)
 
     def _type_key_indicator(self, key):
         return key.split('::', 1)[1]

--- a/minemeld/ft/redis.py
+++ b/minemeld/ft/redis.py
@@ -54,11 +54,14 @@ class RedisSet(actorbase.ActorBaseFT):
     def read_checkpoint(self):
         self._connect_redis()
         self.last_checkpoint = self.SR.get(self.redis_skey_chkp)
-        self.SR.delete(self.redis_skey_chkp)
 
     def create_checkpoint(self, value):
         self._connect_redis()
         self.SR.set(self.redis_skey_chkp, value)
+
+    def remove_checkpoint(self):
+        self._connect_redis()
+        self.SR.delete(self.redis_skey_chkp)
 
     def _connect_redis(self):
         if self.SR is not None:

--- a/minemeld/ft/taxii.py
+++ b/minemeld/ft/taxii.py
@@ -817,11 +817,14 @@ class DataFeed(actorbase.ActorBaseFT):
     def read_checkpoint(self):
         self._connect_redis()
         self.last_checkpoint = self.SR.get(self.redis_skey_chkp)
-        self.SR.delete(self.redis_skey_chkp)
 
     def create_checkpoint(self, value):
         self._connect_redis()
         self.SR.set(self.redis_skey_chkp, value)
+
+    def remove_checkpoint(self):
+        self._connect_redis()
+        self.SR.delete(self.redis_skey_chkp)
 
     def _connect_redis(self):
         if self.SR is not None:

--- a/minemeld/run/launcher.py
+++ b/minemeld/run/launcher.py
@@ -91,11 +91,11 @@ def _parse_args():
     )
     parser.add_argument(
         '--nodes-per-chassis',
-        default=5.0,
+        default=15.0,
         type=float,
         action='store',
         metavar='NPC',
-        help='number of nodes per chassis (default 4)'
+        help='number of nodes per chassis (default 15)'
     )
     parser.add_argument(
         '--verbose',

--- a/tests/test_ft_base.py
+++ b/tests/test_ft_base.py
@@ -86,8 +86,7 @@ class MineMeldFTBaseTests(unittest.TestCase):
                 'get',
                 'get_all',
                 'get_range',
-                'length',
-                'hup'
+                'length'
             ]
         )
 
@@ -123,8 +122,7 @@ class MineMeldFTBaseTests(unittest.TestCase):
                 'get',
                 'get_all',
                 'get_range',
-                'length',
-                'hup'
+                'length'
             ]
         )
 
@@ -169,8 +167,7 @@ class MineMeldFTBaseTests(unittest.TestCase):
                 'get',
                 'get_all',
                 'get_range',
-                'length',
-                'hup'
+                'length'
             ]
         )
 
@@ -239,8 +236,7 @@ class MineMeldFTBaseTests(unittest.TestCase):
                 'get',
                 'get_all',
                 'get_range',
-                'length',
-                'hup'
+                'length'
             ]
         )
 

--- a/tests/test_ft_redis.py
+++ b/tests/test_ft_redis.py
@@ -102,8 +102,7 @@ class MineMeldFTRedisTests(unittest.TestCase):
                 'get',
                 'get_all',
                 'get_range',
-                'length',
-                'hup'
+                'length'
             ]
         )
 
@@ -134,12 +133,12 @@ class MineMeldFTRedisTests(unittest.TestCase):
 
         SR = redis.StrictRedis()
 
-        b.update('a', indicator='testi', value={'test': 'v'})
+        b.filtered_update('a', indicator='testi', value={'test': 'v'})
         sm = SR.zrange(FTNAME, 0, -1)
         self.assertEqual(len(sm), 1)
         self.assertIn('testi', sm)
 
-        b.withdraw('a', indicator='testi')
+        b.filtered_withdraw('a', indicator='testi')
         sm = SR.zrange(FTNAME, 0, -1)
         self.assertEqual(len(sm), 0)
 
@@ -169,18 +168,18 @@ class MineMeldFTRedisTests(unittest.TestCase):
         b.start()
         time.sleep(1)
 
-        b.update('a', indicator='testi', value={'test': 'v'})
+        b.filtered_update('a', indicator='testi', value={'test': 'v'})
         self.assertEqual(b.length(), 1)
         status = b.mgmtbus_status()
         self.assertEqual(status['statistics']['added'], 1)
 
-        b.update('a', indicator='testi', value={'test': 'v2'})
+        b.filtered_update('a', indicator='testi', value={'test': 'v2'})
         self.assertEqual(b.length(), 1)
         status = b.mgmtbus_status()
         self.assertEqual(status['statistics']['added'], 1)
         self.assertEqual(status['statistics']['removed'], 0)
 
-        b.withdraw('a', indicator='testi')
+        b.filtered_withdraw('a', indicator='testi')
         self.assertEqual(b.length(), 0)
         status = b.mgmtbus_status()
         self.assertEqual(status['statistics']['removed'], 1)
@@ -212,14 +211,14 @@ class MineMeldFTRedisTests(unittest.TestCase):
 
         SR = redis.StrictRedis()
 
-        b.update('a', indicator='testi', value={'test': 'v'})
+        b.filtered_update('a', indicator='testi', value={'test': 'v'})
         sm = SR.zrange(FTNAME, 0, -1)
         self.assertEqual(len(sm), 1)
         self.assertIn('testi', sm)
         sm = SR.hlen(FTNAME+'.value')
         self.assertEqual(sm, 1)
 
-        b.withdraw('a', indicator='testi')
+        b.filtered_withdraw('a', indicator='testi')
         sm = SR.zrange(FTNAME, 0, -1)
         self.assertEqual(len(sm), 0)
         sm = SR.hlen(FTNAME+'.value')

--- a/tests/test_ft_taxii.py
+++ b/tests/test_ft_taxii.py
@@ -166,11 +166,11 @@ class MineMeldFTTaxiiTests(unittest.TestCase):
 
         b.start()
         # __init__ + get chkp + delete chkp
-        self.assertEqual(len(SR_mock.mock_calls), 5)
+        self.assertEqual(len(SR_mock.mock_calls), 6)
         SR_mock.reset_mock()
 
         # unicast
-        b.update(
+        b.filtered_update(
             'a',
             indicator='1.1.1.1',
             value={
@@ -197,7 +197,7 @@ class MineMeldFTTaxiiTests(unittest.TestCase):
         SR_mock.reset_mock()
 
         # CIDR
-        b.update(
+        b.filtered_update(
             'a',
             indicator='1.1.1.0/24',
             value={
@@ -224,7 +224,7 @@ class MineMeldFTTaxiiTests(unittest.TestCase):
         SR_mock.reset_mock()
 
         # fake range
-        b.update(
+        b.filtered_update(
             'a',
             indicator='1.1.1.1-1.1.1.1',
             value={
@@ -251,7 +251,7 @@ class MineMeldFTTaxiiTests(unittest.TestCase):
         SR_mock.reset_mock()
 
         # fake range 2
-        b.update(
+        b.filtered_update(
             'a',
             indicator='1.1.1.0-1.1.1.31',
             value={
@@ -278,7 +278,7 @@ class MineMeldFTTaxiiTests(unittest.TestCase):
         SR_mock.reset_mock()
 
         # real range
-        b.update(
+        b.filtered_update(
             'a',
             indicator='1.1.1.0-1.1.1.33',
             value={
@@ -333,11 +333,11 @@ class MineMeldFTTaxiiTests(unittest.TestCase):
 
         b.start()
         # __init__ + get chkp + delete chkp
-        self.assertEqual(len(SR_mock.mock_calls), 5)
+        self.assertEqual(len(SR_mock.mock_calls), 6)
         SR_mock.reset_mock()
 
         # unicast
-        b.update(
+        b.filtered_update(
             'a',
             indicator='example.com',
             value={
@@ -389,11 +389,11 @@ class MineMeldFTTaxiiTests(unittest.TestCase):
 
         b.start()
         # __init__ + get chkp + delete chkp
-        self.assertEqual(len(SR_mock.mock_calls), 5)
+        self.assertEqual(len(SR_mock.mock_calls), 6)
         SR_mock.reset_mock()
 
         # unicast
-        b.update(
+        b.filtered_update(
             'a',
             indicator='www.example.com/admin.php',
             value={
@@ -445,11 +445,11 @@ class MineMeldFTTaxiiTests(unittest.TestCase):
 
         b.start()
         # __init__ + get chkp + delete chkp
-        self.assertEqual(len(SR_mock.mock_calls), 5)
+        self.assertEqual(len(SR_mock.mock_calls), 6)
         SR_mock.reset_mock()
 
         # unicast
-        b.update(
+        b.filtered_update(
             'a',
             indicator=u'☃.net/påth',
             value={


### PR DESCRIPTION
Improvements:
- if *conditions* is *null* in filters, now it is considered an empty list
- now checkpoints are removed after nodes switch from READY state. If a node fails during configuration saved state is still consistent. Useful for recovering from faulty prototypes or faulty configs
- default number of nodes per chassis has been increased to 15

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>