### PR TITLE
Adds support for external extensions API and jobs API

### DIFF
--- a/minemeld/extensions/__init__.py
+++ b/minemeld/extensions/__init__.py
@@ -1,0 +1,1 @@
+from .manager import *  # noqa

--- a/minemeld/extensions/manager.py
+++ b/minemeld/extensions/manager.py
@@ -1,0 +1,316 @@
+import os
+import os.path
+import json
+import logging
+from email.parser import Parser
+from collections import namedtuple
+from zipfile import ZipFile
+
+from pkg_resources import EntryPoint
+from pip.utils import egg_link_path
+
+import minemeld.loader
+
+LOG = logging.getLogger(__name__)
+
+
+__all__ = [
+    'get_metadata_from_wheel',
+    'activated_extensions',
+    'installed_extensions',
+    'extensions',
+    'freeze'
+]
+
+
+METADATA_MAP = {
+    'name': 'Name',
+    'version': 'Version',
+    'author': 'Author',
+    'author_email': 'Author-email',
+    'description': 'Summary',
+    'url': 'Home-page'
+}
+
+
+InstalledExtension = namedtuple(
+    'InstalledExtension',
+    [
+        'name', 'version', 'author', 'author_email',
+        'description', 'url', 'path', 'entry_points'
+    ]
+)
+
+
+ActivatedExtension = namedtuple(
+    'ActivatedExtension',
+    [
+        'name', 'version', 'author', 'author_email',
+        'description', 'url', 'location', 'entry_points'
+    ]
+)
+
+
+ExternalExtension = namedtuple(
+    'ExternalExtension',
+    [
+        'name', 'version', 'author', 'author_email',
+        'description', 'url', 'path', 'activated',
+        'installed', 'entry_points'
+    ]
+)
+
+
+def _read_metadata(metadata_str):
+    return Parser().parsestr(metadata_str)
+
+
+def _read_entry_points(ep_contents):
+    ep_map = EntryPoint.parse_map(ep_contents)
+
+    for epgname, epgroup in ep_map.iteritems():
+        for epname, ep in epgroup.iteritems():
+            epgroup[epname] = str(ep)
+
+    return ep_map
+
+
+def _activated_extensions():
+    epgroups = (
+        minemeld.loader.MM_NODES_ENTRYPOINT,
+        minemeld.loader.MM_NODES_GCS_ENTRYPOINT,
+        minemeld.loader.MM_NODES_VALIDATORS_ENTRYPOINT,
+        minemeld.loader.MM_PROTOTYPES_ENTRYPOINT,
+        minemeld.loader.MM_API_ENTRYPOINT
+    )
+
+    activated_extensions = {}
+
+    for epgroup in epgroups:
+        for _, epvalue in minemeld.loader.map(epgroup).iteritems():
+            if epvalue.ep.dist.project_name == 'minemeld-core':
+                continue
+
+            location = 'site-packages'
+            egg_link = egg_link_path(epvalue.ep.dist)
+            if egg_link is not None:
+                with open(egg_link, 'r') as f:
+                    location = f.readline().strip()
+
+            metadata = {
+                'name': epvalue.ep.dist.project_name,
+                'version': epvalue.ep.dist.version,
+                'author': None,
+                'author_email': None,
+                'description': None,
+                'url': None,
+                'entry_points': None
+            }
+            if egg_link:
+                try:
+                    with open(os.path.join(location, 'minemeld.json'), 'r') as f:
+                        dist_metadata = json.load(f)
+                    for k in metadata.keys():
+                        metadata[k] = dist_metadata.get(k, None)
+
+                except (IOError, OSError) as excpt:
+                    LOG.error('Error loading metatdata from {}: {}'.format(location, str(excpt)))
+
+            elif epvalue.ep.dist.has_metadata('METADATA'):
+                dist_metadata = _read_metadata(
+                    epvalue.ep.dist.get_metadata('METADATA')
+                )
+                for k in metadata.keys():
+                    if k in METADATA_MAP and METADATA_MAP[k] in dist_metadata:
+                        metadata[k] = dist_metadata[METADATA_MAP[k]]
+
+                if epvalue.ep.dist.has_metadata('entry_points.txt'):
+                    metadata['entry_points'] = _read_entry_points(
+                        epvalue.ep.dist.get_metadata('entry_points.txt')
+                    )
+
+            activated_extensions[epvalue.ep.dist.project_name] = ActivatedExtension(
+                location=location,
+                **metadata
+            )
+
+    return activated_extensions
+
+
+def _load_metadata_from_wheel(extpath, extname=None):
+    wheel_name = extname
+    if extname is None:
+        wheel_name = os.path.basename(extpath)
+
+    project_name, version, _ = wheel_name.split('-', 2)
+    metadata_path = '{}-{}.dist-info/METADATA'.format(project_name, version)
+
+    with ZipFile(extpath, 'r') as wheel_file:
+        metadata_file = wheel_file.open(metadata_path, 'r')
+        metadata_lines = metadata_file.read()
+
+    metadata = _read_metadata(metadata_lines)
+
+    # classifier framework :: minemeld should be in METADATA
+    # for this to be an extension
+    classifiers = metadata.get_all('Classifier')
+    if classifiers is None:
+        return None
+
+    for c in classifiers:
+        if c.lower() == 'framework :: minemeld':
+            break
+    else:
+        return None
+
+    ie_metadata = {}
+    for field in InstalledExtension._fields:
+        if field == 'path' or field == 'entry_points':
+            continue
+        ie_metadata[field] = metadata.get(METADATA_MAP[field], None)
+
+    entry_points = None
+
+    try:
+        ep_path = '{}-{}.dist-info/entry_points.txt'.format(project_name, version)
+        with ZipFile(extpath, 'r') as wheel_file:
+            ep_file = wheel_file.open(ep_path, 'r')
+            ep_contents = ep_file.read()
+
+        entry_points = _read_entry_points(ep_contents)
+
+    except (IOError, OSError):
+        pass
+
+    ie_metadata['entry_points'] = entry_points
+
+    return InstalledExtension(
+        path=extpath,
+        **ie_metadata
+    )
+
+
+def _load_metadata_from_dir(extpath):
+    with open(os.path.join(extpath, 'minemeld.json'), 'r') as f:
+        metadata = json.load(f)
+
+    return InstalledExtension(
+        name=metadata['name'],
+        version=metadata['version'],
+        author=metadata['author'],
+        author_email=metadata.get('author_email', None),
+        description=metadata.get('description', None),
+        url=metadata.get('url', None),
+        entry_points=metadata.get('entry_points', None),
+        path=extpath
+    )
+
+
+def _is_activated(installed_extension, activated):
+    activated_extension = activated.get(installed_extension.name, None)
+    if activated_extension is None:
+        return False
+
+    if activated_extension.version != installed_extension.version:
+        return False
+
+    if installed_extension.path == activated_extension.location:
+        return True
+
+    if activated_extension.location == 'site-packages' and \
+       installed_extension.path.endswith('.whl'):
+        return True
+
+    return False
+
+
+def get_metadata_from_wheel(wheelpath, wheelname=None):
+    return _load_metadata_from_wheel(wheelpath, wheelname)
+
+
+def installed_extensions(installation_dir):
+    _installed_extensions = []
+
+    entries = os.listdir(installation_dir)
+
+    for e in entries:
+        epath = os.path.join(installation_dir, e)
+
+        # check if this is a wheel
+        if e.endswith('.whl'):
+            try:
+                installed_extension = _load_metadata_from_wheel(epath)
+                if installed_extension is None:
+                    continue
+
+                _installed_extensions.append(installed_extension)
+
+            except (ValueError, IOError, KeyError, OSError) as excpt:
+                LOG.error(u'Error extracting metadata from {}: {}'.format(e, str(excpt)))
+
+        # check if it is a directory
+        elif os.path.isdir(epath):
+            try:
+                installed_extension = _load_metadata_from_dir(epath)
+                if installed_extension is None:
+                    continue
+
+                _installed_extensions.append(installed_extension)
+
+            except (IOError, OSError, KeyError) as excpt:
+                LOG.error(u'Error extracting metadata from {}: {}'.format(e, str(excpt)))
+
+    return _installed_extensions
+
+
+def activated_extensions():
+    return _activated_extensions()
+
+
+def extensions(installation_dir):
+    _extensions = []
+
+    _installed = installed_extensions(installation_dir)
+    _activated = activated_extensions()
+
+    for installed_extension in _installed:
+        _extension_activated = _is_activated(installed_extension, _activated)
+        _extensions.append(ExternalExtension(
+            installed=True,
+            activated=_extension_activated,
+            **installed_extension._asdict()
+        ))
+        if _extension_activated:
+            _activated.pop(installed_extension.name)
+
+    for _activated_extension in _activated.values():
+        _adict = _activated_extension._asdict()
+        _adict.pop('location')
+        _extensions.append(ExternalExtension(
+            installed=False,
+            activated=True,
+            path=None,
+            **_adict
+        ))
+
+    return _extensions
+
+
+def freeze(installation_dir):
+    _freeze = []
+
+    _extensions = extensions(installation_dir)
+
+    for e in _extensions:
+        if not e.activated:
+            continue
+
+        if not e.installed:
+            continue
+
+        if e.path.endswith('.whl'):
+            _freeze.append(e.path)
+        else:
+            _freeze.append('-e {}'.format(e.path))
+
+    return _freeze

--- a/minemeld/flask/__init__.py
+++ b/minemeld/flask/__init__.py
@@ -27,6 +27,7 @@ REDIS_URL = os.environ.get('REDIS_URL', 'redis://127.0.0.1:6379/0')
 def create_app():
     app = Flask(__name__)
     app.logger.addHandler(logging.StreamHandler())
+    app.config['MAX_CONTENT_LENGTH'] = 5 * 1024 * 1024  # max 5MB for uploads
 
     # extension code
     from . import config
@@ -35,6 +36,7 @@ def create_app():
     from . import mmrpc
     from . import redisclient
     from . import supervisorclient
+    from . import jobs
 
     session.init_app(app, REDIS_URL)
     aaa.LOGIN_MANAGER.init_app(app)
@@ -48,6 +50,7 @@ def create_app():
     mmrpc.init_app(app)
     redisclient.init_app(app)
     supervisorclient.init_app(app)
+    jobs.init_app(app)
 
     # entrypoints
     from . import metricsapi  # noqa
@@ -64,6 +67,8 @@ def create_app():
     from . import statusapi  # noqa
     from . import tracedapi  # noqa
     from . import logsapi  # noqa
+    from . import extensionsapi  # noqa
+    from . import jobsapi  # noqa
 
     configapi.init_app(app)
 
@@ -81,6 +86,8 @@ def create_app():
     app.register_blueprint(aaaapi.BLUEPRINT)
     app.register_blueprint(tracedapi.BLUEPRINT)
     app.register_blueprint(logsapi.BLUEPRINT)
+    app.register_blueprint(extensionsapi.BLUEPRINT)
+    app.register_blueprint(jobsapi.BLUEPRINT)
 
     # install blueprints from extensions
     for apiname, apimmep in minemeld.loader.map(minemeld.loader.MM_API_ENTRYPOINT).iteritems():

--- a/minemeld/flask/extensionsapi.py
+++ b/minemeld/flask/extensionsapi.py
@@ -1,0 +1,493 @@
+#  Copyright 2015-2017 Palo Alto Networks, Inc
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import sys
+import os
+import os.path
+import shutil
+import logging
+import functools
+import subprocess
+import uuid
+import stat
+from tempfile import NamedTemporaryFile
+
+import filelock
+from gevent import Timeout
+from gevent.subprocess import Popen
+from flask import Blueprint, jsonify, request
+from werkzeug.utils import secure_filename
+from flask.ext.login import login_required
+
+import minemeld.extensions
+import minemeld.loader
+
+from . import config
+from .jobs import JOBS_MANAGER
+from .prototypeapi import reset_prototype_paths
+
+
+__all__ = ['BLUEPRINT']
+
+
+LOG = logging.getLogger(__name__)
+
+BLUEPRINT = Blueprint('extensions', __name__, url_prefix='')
+
+
+def _get_extensions():
+    library_directory = config.get('MINEMELD_LOCAL_LIBRARY_PATH', None)
+    if library_directory is None:
+        raise RuntimeError('MINEMELD_LOCAL_LIBRARY_PATH not set')
+
+    return minemeld.extensions.extensions(library_directory)
+
+
+def _build_activate_args(ext_path):
+    pip_path = config.get('MINEMELD_PIP_PATH', None)
+    if pip_path is None:
+        raise RuntimeError('MINEMELD_PIP_PATH not set')
+
+    library_directory = config.get('MINEMELD_LOCAL_LIBRARY_PATH', None)
+    if library_directory is None:
+        raise RuntimeError('MINEMELD_LOCAL_LIBRARY_PATH not set')
+
+    constraints_file = os.path.join(library_directory, 'constraints.txt')
+
+    args = [
+        pip_path,
+        'install',
+        '-c', constraints_file
+    ]
+    if ext_path.endswith('.whl'):
+        args.append(ext_path)
+    else:
+        args.append('-e')
+        args.append(ext_path)
+
+    return args
+
+
+def _build_deactivate_args(extension_name):
+    pip_path = config.get('MINEMELD_PIP_PATH', None)
+    if pip_path is None:
+        raise RuntimeError('MINEMELD_PIP_PATH not set')
+
+    args = [
+        pip_path,
+        'uninstall', '-y',
+        extension_name
+    ]
+
+    return args
+
+
+def _find_running_job(extension, jobs):
+    for jobid, job in jobs.iteritems():
+        if job['status'] != 'RUNNING':
+            continue
+
+        if job['name'] == extension.name:
+            return jobid
+
+    return None
+
+
+def _update_freeze_file():
+    library_directory = config.get('MINEMELD_LOCAL_LIBRARY_PATH', None)
+    if library_directory is None:
+        LOG.error('freeze not updated - MINEMELD_LOCAL_LIBRARY_PATH not set')
+        return
+
+    freeze_path = os.path.join(library_directory, 'freeze.txt')
+
+    freeze_lock = filelock.FileLock('{}.lock'.format(freeze_path))
+    with freeze_lock.acquire(timeout=30):
+        with open(freeze_path, 'w+') as ff:
+            frozen = minemeld.extensions.freeze(library_directory)
+            for frozen_ext in frozen:
+                ff.write('{}\n'.format(frozen_ext))
+
+
+def _extensions_changed(activated_path, deactivated_path, g):
+    if g.value == 0:
+        # process was successful
+        if deactivated_path is not None:
+            try:
+                sys.path.remove(deactivated_path)
+            except ValueError:
+                pass
+
+        if activated_path is not None:
+            if activated_path not in sys.path:
+                sys.path.append(activated_path)
+
+    minemeld.loader.bump_workingset()
+    reset_prototype_paths()
+    _update_freeze_file()
+
+
+def _safe_remove(path, g=None):
+    try:
+        os.remove(path)
+    except:
+        LOG.exception('Exception removing {}'.format(path))
+
+
+@BLUEPRINT.route('/extensions', methods=['GET'])
+@login_required
+def list_extensions():
+    extensions = _get_extensions()
+
+    jobs = JOBS_MANAGER.get_jobs('extensions')
+
+    result = []
+    for e in extensions:
+        edict = e._asdict()
+        rjobid = _find_running_job(e, jobs)
+        if rjobid is not None:
+            edict['running_job'] = rjobid
+
+        result.append(edict)
+
+    return jsonify(result=result)
+
+
+@BLUEPRINT.route('/extensions/<extension>/activate', methods=['POST'])
+@login_required
+def activate_extension(extension):
+    params = request.get_json(silent=True)
+    if params is None:
+        return jsonify(error={'message': 'no params'}), 400
+
+    ext_path = params.get('path', None)
+    if ext_path is None:
+        return jsonify(error={'message': 'path not specified'}), 400
+
+    ext_version = params.get('version', None)
+    if ext_version is None:
+        return jsonify(error={'message': 'version not specified'}), 400
+
+    extensions = _get_extensions()
+
+    for e in extensions:
+        if e.name != extension:
+            continue
+
+        if e.version != ext_version:
+            continue
+
+        if e.path == ext_path:
+            break
+    else:
+        return jsonify(error={'message': 'extension not found'}), 400
+
+    if not e.installed:
+        return jsonify(error={'message': 'extension not installed'}), 400
+
+    if e.activated:
+        return jsonify(error={'messsage': 'extension already activated'}), 400
+
+    jobs = JOBS_MANAGER.get_jobs('extensions')
+    if _find_running_job(e, jobs) is not None:
+        return jsonify(error={'message': 'pending job'}), 400
+
+    jobid = JOBS_MANAGER.exec_job(
+        job_group='extensions',
+        description='activate {} v{}'.format(e.name, e.version),
+        args=_build_activate_args(e.path),
+        data={
+            'name': extension,
+            'version': ext_version,
+            'path': ext_path
+        },
+        callback=functools.partial(_extensions_changed, e.path, None)
+    )
+
+    return jsonify(result=jobid)
+
+
+@BLUEPRINT.route('/extensions/<extension>/deactivate', methods=['GET', 'POST'])
+@login_required
+def deactivate_extension(extension):
+    params = request.get_json(silent=True)
+    if params is None:
+        return jsonify(error={'message': 'no params'}), 400
+
+    ext_path = params.get('path', None)
+    if ext_path is None:
+        return jsonify(error={'message': 'path not specified'}), 400
+
+    ext_version = params.get('version', None)
+    if ext_version is None:
+        return jsonify(error={'message': 'version not specified'}), 400
+
+    extensions = _get_extensions()
+
+    for e in extensions:
+        if e.name != extension:
+            continue
+
+        if e.version != ext_version:
+            continue
+
+        if e.path == ext_path:
+            break
+    else:
+        return jsonify(error={'message': 'extension not found'}), 400
+
+    if not e.installed:
+        return jsonify(error={'message': 'extension not installed'}), 400
+
+    if not e.activated:
+        return jsonify(error={'messsage': 'extension not activated'}), 400
+
+    jobs = JOBS_MANAGER.get_jobs('extensions')
+    if _find_running_job(e, jobs) is not None:
+        return jsonify(error={'message': 'pending job'}), 400
+
+    jobid = JOBS_MANAGER.exec_job(
+        job_group='extensions',
+        description='deactivate {} v{}'.format(e.name, e.version),
+        args=_build_deactivate_args(extension),
+        data={
+            'name': extension,
+            'version': ext_version,
+            'path': ext_path
+        },
+        callback=functools.partial(_extensions_changed, None, e.path)
+    )
+
+    return jsonify(result=jobid)
+
+
+@BLUEPRINT.route('/extensions/<extension>/uninstall', methods=['GET', 'POST'])
+@login_required
+def uninstall_extension(extension):
+    params = request.get_json(silent=True)
+    if params is None:
+        return jsonify(error={'message': 'no params'}), 400
+
+    ext_path = params.get('path', None)
+    if ext_path is None:
+        return jsonify(error={'message': 'path not specified'}), 400
+
+    ext_version = params.get('version', None)
+    if ext_version is None:
+        return jsonify(error={'message': 'version not specified'}), 400
+
+    extensions = _get_extensions()
+
+    for e in extensions:
+        if e.name != extension:
+            continue
+
+        if e.version != ext_version:
+            continue
+
+        if e.path == ext_path:
+            break
+    else:
+        return jsonify(error={'message': 'extension not found'}), 400
+
+    if not e.installed:
+        return jsonify(error={'message': 'extension not installed'}), 400
+
+    if e.activated:
+        return jsonify(error={'messsage': 'extension activated'}), 400
+
+    jobs = JOBS_MANAGER.get_jobs('extensions')
+    if _find_running_job(e, jobs) is not None:
+        return jsonify(error={'message': 'pending job'}), 400
+
+    if e.path.endswith('.whl'):
+        os.remove(e.path)
+
+    else:
+        shutil.rmtree(e.path)
+
+    _extensions_changed(None, None, None)
+
+    return jsonify(result='ok')
+
+
+@BLUEPRINT.route('/extensions', methods=['POST'])
+@login_required
+def upload_extension():
+    library_directory = config.get('MINEMELD_LOCAL_LIBRARY_PATH', None)
+    if library_directory is None:
+        raise RuntimeError('MINEMELD_LOCAL_LIBRARY_PATH not set')
+
+    if 'file' not in request.files:
+        return jsonify(error={'messsage': 'No file'}), 400
+
+    file = request.files['file']
+    if file.filename == '':
+        return jsonify(error={'message': 'No file'}), 400
+
+    if not file or not file.filename.endswith('.whl'):
+        return jsonify(error={'message': 'Incorrect filename'}), 400
+
+    filename = secure_filename(file.filename)
+    if filename != file.filename:
+        return jsonify(error={'message': 'Incorrect filename'}), 400
+    if os.path.basename(filename) != filename:
+        return jsonify(error={'message': 'Incorrect filename'}), 400
+
+    toks = filename.split('-', 5)
+    if len(toks) != 4 and len(toks) != 5:
+        return jsonify(error={'message': 'Invalid wheel filename'}), 400
+
+    if toks[-1] != 'any.whl' and toks[-1] != 'linux_x86_64.whl':
+        return jsonify(error={'message': 'Invalid wheel platform'}), 400
+
+    if not toks[-3].startswith('py2') and not toks[-3].startswith('cp2'):
+        return jsonify(error={'message': 'Invalid wheel python version'}), 400
+
+    tf = NamedTemporaryFile(prefix='mm-extension-upload', delete=False)
+
+    try:
+        file.save(tf)
+        tf.close()
+
+        metadata = minemeld.extensions.get_metadata_from_wheel(tf.name, filename)
+        if metadata is None:
+            return jsonify(error={'message': 'Invalid MineMeld extension'}), 400
+
+        full_filename = os.path.join(library_directory, filename)
+        shutil.move(tf.name, full_filename)
+
+    except (KeyError, ValueError) as e:
+        LOG.error('Invalid extension: {}'.format(str(e)))
+        return jsonify(error={'message': 'Invalid python wheel'}), 400
+
+    finally:
+        _safe_remove(tf.name)
+
+    return jsonify(result='OK')
+
+
+@BLUEPRINT.route('/extensions/git-refs', methods=['GET'])
+@login_required
+def get_git_refs():
+    git_endpoint = request.values.get('ep', None)
+    if git_endpoint is None:
+        return jsonify(error={'message': 'Missing endpoint'}), 400
+
+    if not git_endpoint.endswith('.git'):
+        return jsonify(error={'message': 'Invalid git endpoint'}), 400
+
+    git_path = config.get('MINEMELD_GIT_PATH', None)
+    if git_path is None:
+        return jsonify(error={'message': 'MINEMELD_GIT_PATH not set'}), 500
+
+    git_args = [git_path, 'ls-remote', '-t', '-h', git_endpoint]
+
+    git_process = Popen(
+        args=git_args,
+        close_fds=True,
+        shell=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    )
+
+    timeout = Timeout(20.0)
+    timeout.start()
+    try:
+        git_stdout, git_stderr = git_process.communicate()
+
+    except Timeout:
+        git_process.kill()
+        return jsonify(error={'message': 'Timeout accessing git repo'}), 400
+
+    finally:
+        timeout.cancel()
+
+    if git_process.returncode != 0:
+        LOG.error('Error running {}: {}'.format(git_args, git_stderr))
+        return jsonify(error={'message': 'Error running git: {}'.format(git_stderr)}), 400
+
+    return jsonify(result=[line.rsplit('/', 1)[-1] for line in git_stdout.splitlines()])
+
+
+@BLUEPRINT.route('/extensions/git-install', methods=['POST'])
+@login_required
+def install_from_git():
+    library_directory = config.get('MINEMELD_LOCAL_LIBRARY_PATH', None)
+    if library_directory is None:
+        raise RuntimeError('MINEMELD_LOCAL_LIBRARY_PATH not set')
+
+    params = request.get_json(silent=True)
+    if params is None:
+        return jsonify(error={'message': 'no params'}), 400
+
+    git_endpoint = params.get('ep', None)
+    if git_endpoint is None:
+        return jsonify(error={'message': 'Missing endpoint'}), 400
+
+    if not git_endpoint.endswith('.git'):
+        return jsonify(error={'message': 'Invalid git endpoint'}), 400
+
+    git_ref = params.get('ref', None)
+    if git_ref is None:
+        return jsonify(error={'message': 'Missing git ref'}), 400
+
+    git_path = config.get('MINEMELD_GIT_PATH', None)
+    if git_path is None:
+        return jsonify(error={'message': 'MINEMELD_GIT_PATH not set'}), 500
+
+    install_directory = os.path.join(
+        library_directory,
+        str(uuid.uuid4())
+    )
+    git_args = [
+        git_path,
+        'clone',
+        '-b', git_ref,
+        '--depth', '1',
+        git_endpoint,
+        install_directory
+    ]
+
+    tf = NamedTemporaryFile(prefix='mm-extension-upload', delete=False)
+
+    try:
+        tf.write('#!/bin/bash\n')
+        tf.write('set -e\n')
+        tf.write('{}\n'.format(' '.join(git_args)))
+        tf.write('if [ ! -f {}/minemeld.json ]; then\n'.format(install_directory))
+        tf.write('  >&2 echo "Invalid MineMeld extension - minemeld.json not found"\n')
+        tf.write('  /bin/rm -rf {}\n'.format(install_directory))
+        tf.write('  exit 1\n')
+        tf.write('fi\n')
+        tf.close()
+        os.chmod(tf.name, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+
+        jobid = JOBS_MANAGER.exec_job(
+            job_group='extensions-git',
+            description='install from git {} branch {}'.format(git_endpoint, git_ref),
+            args=[tf.name],
+            data={
+                'endpoint': git_endpoint,
+                'ref': git_ref,
+                'path': install_directory
+            },
+            callback=functools.partial(_safe_remove, tf.name)
+        )
+
+    except:
+        _safe_remove(tf.name)
+        raise
+
+    return jsonify(result=jobid)

--- a/minemeld/flask/jobs.py
+++ b/minemeld/flask/jobs.py
@@ -1,0 +1,250 @@
+#  Copyright 2017 Palo Alto Networks, Inc
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+import uuid
+import logging
+import tempfile
+import subprocess
+import shutil
+import json
+import time
+from collections import namedtuple, defaultdict
+
+import redis
+import psutil
+import werkzeug.local
+import gevent
+from gevent.subprocess import Popen
+
+from flask import g
+from . import REDIS_URL
+from . import config
+
+
+__all__ = ['init_app', 'JOBS_MANAGER']
+
+
+LOG = logging.getLogger(__name__)
+
+REDIS_CP = redis.ConnectionPool.from_url(
+    REDIS_URL,
+    max_connections=int(os.environ.get('REDIS_MAX_CONNECTIONS', 5))
+)
+
+REDIS_JOBS_GROUP_PREFIX = 'mm-jobs-{}'
+
+
+_Job = namedtuple('_Job', field_names=['glet'])
+
+
+class JobsManager(object):
+    def __init__(self, connection_pool):
+        self.SR = redis.StrictRedis(connection_pool=connection_pool)
+        self.running_jobs = defaultdict(dict)
+
+    def _safe_rmtree(self, path):
+        shutil.rmtree(path, ignore_errors=True)
+
+    def _safe_remove(self, path):
+        try:
+            os.remove(path)
+        except:
+            pass
+
+    def _get_job_status(self, jobpid, jobhash):
+        try:
+            jobprocess = psutil.Process(pid=jobpid)
+
+        except psutil.NoSuchProcess:
+            return {
+                'status': 'DONE',
+                'returncode': None
+            }
+
+        if hash(jobprocess) != jobhash:
+            return {
+                'status': 'DONE',
+                'returncode': None
+            }
+
+        return {
+            'status': 'RUNNING'
+        }
+
+    def _collect_job(self, jobdata):
+        if 'collected' in jobdata:
+            return
+
+        tempdir = jobdata.get('cwd', None)
+        if tempdir is not None:
+            self._safe_rmtree(tempdir)
+
+        jobdata['collected'] = True
+
+    def _job_monitor_glet(self, job_group, jobid, description, args, data):
+        jobname = (REDIS_JOBS_GROUP_PREFIX+'-{}').format(job_group, jobid)
+        joblogfile = os.path.join(
+            config.get('MINEMELD_LOG_DIRECTORY_PATH', '/tmp'),
+            '{}.log'.format(jobname)
+        )
+        jobtempdir = tempfile.mkdtemp(prefix=jobname)
+
+        LOG.info('Executing job {} - {} cwd: {} logfile: {}'.format(jobname, args, jobtempdir, joblogfile))
+
+        try:
+            with open(joblogfile, 'w+') as logfile:
+                jobprocess = Popen(
+                    args=args,
+                    close_fds=True,
+                    cwd=jobtempdir,
+                    shell=False,
+                    stdout=logfile,
+                    stderr=subprocess.STDOUT
+                )
+
+        except OSError:
+            self._safe_remove(joblogfile)
+            self._safe_rmtree(jobtempdir)
+            LOG.exception('Error starting job {}'.format(jobname))
+            return
+
+        jobpsproc = psutil.Process(pid=jobprocess.pid)
+
+        jobdata = data
+        if jobdata is None:
+            jobdata = {}
+
+        jobdata['create_time'] = int(time.time()*1000)
+        jobdata['description'] = description
+        jobdata['job_id'] = jobid
+        jobdata['pid'] = jobpsproc.pid
+        jobdata['hash'] = hash(jobpsproc)
+        jobdata['logfile'] = joblogfile
+        jobdata['cwd'] = jobtempdir
+        jobdata['status'] = 'RUNNING'
+
+        self.SR.hset(
+            REDIS_JOBS_GROUP_PREFIX.format(job_group),
+            jobid,
+            json.dumps(jobdata)
+        )
+
+        jobprocess.wait()
+
+        if jobprocess.returncode != 0:
+            jobdata['status'] = 'ERROR'
+        else:
+            jobdata['status'] = 'DONE'
+        jobdata['returncode'] = jobprocess.returncode
+        jobdata['end_time'] = int(time.time()*1000)
+
+        self._collect_job(jobdata)
+
+        self.SR.hset(
+            REDIS_JOBS_GROUP_PREFIX.format(job_group),
+            jobid,
+            json.dumps(jobdata)
+        )
+
+        self.running_jobs[job_group].pop(jobid, None)
+
+        return jobprocess.returncode
+
+    def delete_job(self, job_group, jobid):
+        prefix = REDIS_JOBS_GROUP_PREFIX.format(job_group)
+
+        jobdata = self.SR.hget(prefix, jobid)
+        if jobdata is None:
+            return
+
+        jobdata = json.loads(jobdata)
+
+        logfile = jobdata.get('logfile', None)
+        if logfile is not None:
+            self._safe_remove(logfile)
+
+        self._collect_job(jobdata)
+
+        self.SR.hdel(prefix, jobid)
+
+    def get_jobs(self, job_group):
+        prefix = REDIS_JOBS_GROUP_PREFIX.format(job_group)
+        result = {}
+
+        jobs_map = self.SR.hgetall(prefix)
+
+        for jobid, jobdata in jobs_map.iteritems():
+            try:
+                jobdata = json.loads(jobdata)
+
+                if jobdata['status'] == 'RUNNING':
+                    jobpid = jobdata['pid']
+                    job_status = self._get_job_status(jobpid, jobdata['hash'])
+                    jobdata.update(job_status)
+
+                result[jobid] = jobdata
+
+            except (ValueError, KeyError, psutil.ZombieProcess, psutil.AccessDenied):
+                LOG.error('Invalid job value - deleting job {}::{}'.format(job_group, jobid))
+                self.delete_job(job_group, jobid)
+                continue
+
+            if jobdata['status'] == 'DONE' and 'collected' not in jobdata:
+                if jobid not in self.running_jobs[job_group]:
+                    self._collect_job(jobdata)
+                    self.SR.hset(job_group, jobid, json.dumps(jobdata))
+
+        return result
+
+    def exec_job(self, job_group, description, args, data=None, callback=None):
+        jobid = str(uuid.uuid4())
+
+        glet = gevent.spawn(
+            self._job_monitor_glet,
+            job_group, jobid, description, args, data
+        )
+        if callback is not None:
+            glet.link(callback)
+
+        self.running_jobs[job_group][jobid] = _Job(glet=glet)
+
+        return jobid
+
+
+def get_JobsManager():
+    jobsmgr = getattr(g, '_jobs_manager', None)
+    if jobsmgr is None:
+        jobsmgr = JobsManager(connection_pool=REDIS_CP)
+        g._jobs_manager = jobsmgr
+    return jobsmgr
+
+
+def teardown(exception):
+    jobsmgr = getattr(g, '_jobs_manager', None)
+    if jobsmgr is not None:
+        g._jobs_manager = None
+        LOG.info(
+            'redis connection pool: in use: {} available: {}'.format(
+                len(REDIS_CP._in_use_connections),
+                len(REDIS_CP._available_connections)
+            )
+        )
+
+
+JOBS_MANAGER = werkzeug.local.LocalProxy(get_JobsManager)
+
+
+def init_app(app):
+    app.teardown_appcontext(teardown)

--- a/minemeld/flask/jobsapi.py
+++ b/minemeld/flask/jobsapi.py
@@ -1,0 +1,64 @@
+#  Copyright 2015-2017 Palo Alto Networks, Inc
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+import os.path
+import logging
+
+from flask import send_from_directory, Blueprint, jsonify
+from flask.ext.login import login_required
+
+from .jobs import JOBS_MANAGER
+
+
+__all__ = ['BLUEPRINT']
+
+
+LOG = logging.getLogger(__name__)
+
+BLUEPRINT = Blueprint('jobs', __name__, url_prefix='/jobs')
+
+
+@BLUEPRINT.route('/<job_group>', methods=['GET'])
+@login_required
+def get_jobs(job_group):
+    jobs = JOBS_MANAGER.get_jobs(job_group)
+
+    return jsonify(result=jobs)
+
+
+@BLUEPRINT.route('/<job_group>/<jobid>', methods=['GET'])
+@login_required
+def get_job(job_group, jobid):
+    jobs = JOBS_MANAGER.get_jobs(job_group)
+    if jobid not in jobs:
+        return jsonify(error={'message': 'job unknown'}), 400
+
+    return jsonify(result=jobs[jobid])
+
+
+@BLUEPRINT.route('/<job_group>/<jobid>/log', methods=['GET'])
+@login_required
+def get_job_log(job_group, jobid):
+    jobs = JOBS_MANAGER.get_jobs(job_group)
+    if jobid not in jobs:
+        return jsonify(error={'message': 'job unknown'}), 400
+
+    job = jobs[jobid]
+
+    return send_from_directory(
+        os.path.dirname(job['logfile']),
+        os.path.basename(job['logfile']),
+        as_attachment=True
+    )

--- a/minemeld/flask/prototypeapi.py
+++ b/minemeld/flask/prototypeapi.py
@@ -19,7 +19,7 @@ import os.path
 
 import yaml
 import filelock
-from flask import g, jsonify, request, Blueprint
+from flask import jsonify, request, Blueprint
 from flask.ext.login import login_required
 
 import minemeld.loader
@@ -38,11 +38,13 @@ LOCAL_PROTOTYPE_PATH = 'MINEMELD_LOCAL_PROTOTYPE_PATH'
 
 BLUEPRINT = Blueprint('prototype', __name__, url_prefix='')
 
+PROTOTYPE_PATHS = None
+
 
 def _prototype_paths():
-    paths = getattr(g, 'prototype_paths', None)
-    if paths is not None:
-        return paths
+    global PROTOTYPE_PATHS
+    if PROTOTYPE_PATHS is not None:
+        return PROTOTYPE_PATHS
 
     paths = config.get(PROTOTYPE_ENV, None)
     if paths is None:
@@ -60,7 +62,7 @@ def _prototype_paths():
         except:
             LOG.exception('Exception loading paths from {}'.format(pname))
 
-    g.prototype_paths = paths
+    PROTOTYPE_PATHS = paths
 
     return paths
 
@@ -315,3 +317,8 @@ def delete_local_prototype(prototypename):
             yaml.safe_dump(library_contents, f, indent=4, default_flow_style=False)
 
     return jsonify(result='OK'), 200
+
+
+def reset_prototype_paths():
+    global PROTOTYPE_PATHS
+    PROTOTYPE_PATHS = None

--- a/minemeld/flask/supervisorapi.py
+++ b/minemeld/flask/supervisorapi.py
@@ -1,4 +1,4 @@
-#  Copyright 2015 Palo Alto Networks, Inc
+#  Copyright 2015-2017 Palo Alto Networks, Inc
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -12,10 +12,12 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import os
 import logging
+import time
+from signal import SIGHUP
 
 import psutil
-import time
 import gevent
 import xmlrpclib
 import supervisor.xmlrpc
@@ -133,5 +135,16 @@ def restart_minemeld_engine():
         }), 400
 
     gevent.spawn(_restart_engine)
+
+    return jsonify(result='OK')
+
+
+@BLUEPRINT.route('/supervisor/minemeld-web/hup', methods=['GET'])
+@login_required
+def hup_minemeld_web():
+    info = MMSupervisor.supervisor.getProcessInfo('minemeld-web')
+
+    apipid = info['pid']
+    os.kill(apipid, SIGHUP)
 
     return jsonify(result='OK')

--- a/minemeld/loader.py
+++ b/minemeld/loader.py
@@ -2,7 +2,7 @@ import logging
 
 import pip
 
-from pkg_resources import iter_entry_points
+from pkg_resources import WorkingSet
 from collections import namedtuple
 
 
@@ -20,6 +20,8 @@ MMEntryPoint = namedtuple(
 )
 
 _ENTRYPOINT_GROUPS = {}
+
+_WS = WorkingSet()
 
 
 def _installed_versions():
@@ -51,7 +53,7 @@ def _initialize_entry_point_group(entrypoint_group):
 
     cache = {}
     result = {}
-    for ep in iter_entry_points(entrypoint_group):
+    for ep in _WS.iter_entry_points(entrypoint_group):
         egg_name = ep.dist.egg_name()
         conflicts = cache.get(egg_name, None)
         if conflicts is None:
@@ -74,6 +76,13 @@ def _initialize_entry_point_group(entrypoint_group):
         )
 
     _ENTRYPOINT_GROUPS[entrypoint_group] = result
+
+
+def bump_workingset():
+    global _WS, _ENTRYPOINT_GROUPS
+
+    _WS = WorkingSet()
+    _ENTRYPOINT_GROUPS = {}
 
 
 def list(entrypoint_group):

--- a/minemeld/run/freeze.py
+++ b/minemeld/run/freeze.py
@@ -1,0 +1,63 @@
+#  Copyright 2017 Palo Alto Networks, Inc
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import sys
+import logging
+import argparse
+
+import minemeld.extensions
+from minemeld import __version__
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        description="Freeze MineMeld extensions"
+    )
+    parser.add_argument(
+        '--version',
+        action='version',
+        version=__version__
+    )
+    parser.add_argument(
+        'library',
+        action='store',
+        metavar='LIBRARY',
+        help='path of the MineMeld library directory'
+    )
+    parser.add_argument(
+        'outfile',
+        action='store',
+        metavar='OUTFILE',
+        default='-',
+        nargs='?',
+        help='path of the file to write the output to. (default: stdout)'
+    )
+    return parser.parse_args()
+
+
+def main():
+    logging.basicConfig(level=logging.DEBUG)
+
+    args = _parse_args()
+
+    if args.outfile == '-':
+        of = sys.stdout
+    else:
+        of = open(args.outfile, 'w+')
+
+    frozenext = minemeld.extensions.freeze(args.library)
+    for e in frozenext:
+        of.write('{}\n'.format(e))
+
+    of.close()

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,8 @@ setup(
             'mm-console = minemeld.run.console:main',
             'mm-traced = minemeld.traced.main:main',
             'mm-traced-purge = minemeld.traced.purge:main',
-            'mm-supervisord-listener = minemeld.supervisord.listener:main'
+            'mm-supervisord-listener = minemeld.supervisord.listener:main',
+            'mm-extensions-freeze = minemeld.run.freeze:main'
         ],
         'minemeld_nodes': _entry_points['minemeld_nodes'],
         'minemeld_nodes_gcs': _entry_points['minemeld_nodes_gcs'],


### PR DESCRIPTION
## Motivation

This PR introduces changes for supporting #113 via API. Using the API users can install extensions from wheel files or git repos, uninstall extensions, activate & deactivate them.

## Modifications

A good number of modifications to achieve the goal:
- added API endpoint to list activated/installed extensions
- added API endpoint to upload extensions wheel files
- added API endpoint to retrieve extensions from git repos
- added API endpoint to retrieve refs from git repos (UI helper)
- added API endpoint to uninstall (i.e. delete) installed extensions
- added API endpoint to activate extensions
- added API endpoint to deactivate extensions
- since activation/deactivation and git ops could be long running, a new frameworks has been introduced to let the API run long running tasks in background (jobs.py)
- added API endpoint to get list of running jobs and their status
- added API endpoint to restart (actually HUP) API process (minemeld-web)
- added CLI utility to *freeze* activated extensions

Changes to environment:
- a new file is introduced called *constraints.txt* in extension library directory. The file is the list of python packages installed by minemeld-core as dumped via *pip freeze*. This is used during activation to avoid conflicts between extensions and minemeld-core, actually to avoid extensions overriding minemeld-core packages and preventing the engine from running. This file should be created by the installation procedure.
- a new file is introduced in extension library directory called *freeze.txt*. This file is updated every time a new extensions is activated and deactivated. *freeze.txt* can be used to restore the status of the external extensions in a new installation.

Changes to API config:
- *MINEMELD_LOCAL_LIBRARY_PATH* path to the extension library directory
- *MINEMELD_PIP_PATH* path to the pip executable to be used for activation/deactivation
- *MINEMELD_GIT_PATH* path to the git executable to be used for retrieving and cloning git repos.

## Result

Users can use the API (via WebUI typically) to upload, retrieve, uninstall, activate and deactivate extensions.

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>