### PR TITLE
Adds read_write role to admins and audit logs

### DIFF
--- a/minemeld/flask/__init__.py
+++ b/minemeld/flask/__init__.py
@@ -18,16 +18,17 @@ import logging
 from flask import Flask
 
 import minemeld.loader
+from .logger import LOG
 
-
-LOG = logging.getLogger(__name__)
 REDIS_URL = os.environ.get('REDIS_URL', 'redis://127.0.0.1:6379/0')
 
 
 def create_app():
     app = Flask(__name__)
-    app.logger.addHandler(logging.StreamHandler())
+
     app.config['MAX_CONTENT_LENGTH'] = 5 * 1024 * 1024  # max 5MB for uploads
+
+    LOG.init_app(app)
 
     # extension code
     from . import config
@@ -39,13 +40,13 @@ def create_app():
     from . import jobs
 
     session.init_app(app, REDIS_URL)
-    aaa.LOGIN_MANAGER.init_app(app)
+    aaa.init_app(app)
 
     config.init()
     if config.get('DEBUG', False):
-        app.logger.setLevel(logging.DEBUG)
+        logging.getLogger().setLevel(logging.DEBUG)
     else:
-        app.logger.setLevel(logging.INFO)
+        logging.getLogger().setLevel(logging.INFO)
 
     mmrpc.init_app(app)
     redisclient.init_app(app)

--- a/minemeld/flask/aaa.py
+++ b/minemeld/flask/aaa.py
@@ -12,20 +12,131 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import flask.ext.login
-
-import logging
+import json
 import base64
+from functools import wraps
+
+import flask.ext.login
+from flask import current_app, Blueprint, request
 
 from . import config
+from .logger import LOG
 
 
-LOG = logging.getLogger(__name__)
-
-LOGIN_MANAGER = flask.ext.login.LoginManager()
-LOGIN_MANAGER.session_protection = None
 ANONYMOUS = 'mm-anonymous'
 
+
+class MMBlueprint(Blueprint):
+    def _audit(self, f, audit_required):
+        if not audit_required:
+            return f
+
+        @wraps(f)
+        def audited_view(*args, **kwargs):
+            if request and flask.ext.login.current_user:
+                params = []
+
+                for key, values in request.values.iterlists():
+                    if key == '_':
+                        continue
+
+                    params.append(('value:{}'.format(key), values))
+
+                for filename, files in request.files.iterlists():
+                    params.append(('file:{}'.format(filename), [file.filename for file in files]))
+
+                body = request.get_json(silent=True)
+                if body is not None:
+                    params.append(['jsonbody', json.dumps(body)[:1024]])
+
+                LOG.audit(
+                    user_id=flask.ext.login.current_user.get_id(),
+                    action_name='{} {}'.format(request.method, request.path),
+                    params=params
+                )
+
+            else:
+                LOG.critical('no request or current_user in audited_view')
+
+            return f(*args, **kwargs)
+
+        return audited_view
+
+    def _login_required(self, f, login_required, read_write, feeds):
+        @wraps(f)
+        def decorated_view(*args, **kwargs):
+            if not login_required:
+                return f(*args, **kwargs)
+
+            if not config.get('API_AUTH_ENABLED', True) and not feeds:
+                return f(*args, **kwargs)
+
+            if not config.get('FEEDS_AUTH_ENABLED', False) and feeds:
+                return f(*args, **kwargs)
+
+            if not feeds:
+                if not flask.ext.login.current_user.is_authenticated():
+                    return current_app.login_manager.unauthorized()
+                if flask.ext.login.current_user.get_id().startswith('feeds/'):
+                    return current_app.login_manager.unauthorized()
+
+            if read_write and not flask.ext.login.current_user.is_read_write():
+                return 'Forbidden', 403
+
+            return f(*args, **kwargs)
+
+        return decorated_view
+
+    def route(self, rule, **options):
+        def decorator(f):
+            login_required = options.pop('login_required', True)
+            read_write = options.pop('read_write', True)
+            feeds = options.pop("feeds", False)
+
+            super_decorator = super(MMBlueprint, self).route(rule, **options)
+
+            return super_decorator(
+                self._audit(
+                    self._login_required(f, login_required, read_write, feeds),
+                    read_write
+                )
+            )
+
+        return decorator
+
+
+class MMAnonynmousUser(object):
+    def __init__(self):
+        self._id = ANONYMOUS
+
+    def get_id(self):
+        return self._id
+
+    def is_authenticated(self):
+        return False
+
+    def is_active(self):
+        return True
+
+    def is_anonymous(self):
+        return True
+
+    def is_read_write(self):
+        return False
+
+    def check_feed(self, feedname):
+        if not config.get('FEEDS_AUTH_ENABLED', False):
+            return True
+
+        fattributes = config.get('FEEDS_ATTRS', None)
+        if fattributes is None or feedname not in fattributes:
+            return False
+        ftags = set(fattributes[feedname].get('tags', []))
+
+        if 'anonymous' in ftags:
+            return True
+
+        return False
 
 class MMAuthenticatedUser(object):
     def __init__(self, _id=None):
@@ -45,23 +156,41 @@ class MMAuthenticatedUser(object):
 
 
 class MMAuthenticatedAdminUser(MMAuthenticatedUser):
-    def check_feed(self, feedname):
-        return True
+    def __init__(self, _id):
+        super(MMAuthenticatedAdminUser, self).__init__(_id=u'admin/{}'.format(_id))
 
+    def is_read_write(self):
+        read_write = config.get('READ_WRITE', None)
+        if read_write is None:
+            return True
 
-class MMAnonymousAdminUser(MMAuthenticatedUser):
-    def __init__(self):
-        super(MMAnonymousAdminUser, self).__init__(_id=ANONYMOUS)
+        if isinstance(read_write, str) or isinstance(read_write, unicode):
+            read_write = read_write.split(',')
+        elif not isinstance(read_write, list):
+            LOG.error('Unknown READ_WRITE format')
+            return False
 
-    def is_anonymous(self):
-        return True
+        if self._id[6:] in read_write:
+            return True
 
-    def check_feed(self, feedname):
         return False
+
+    def check_feed(self, feedname):
+        return True
 
 
 class MMAuthenticatedFeedUser(MMAuthenticatedUser):
+    def __init__(self, _id):
+        super(MMAuthenticatedFeedUser, self).__init__(_id=u'feeds/{}'.format(_id))
+
+    def is_read_write(self):
+        # this should never be called
+        return False
+
     def check_feed(self, feedname):
+        if not config.get('FEEDS_AUTH_ENABLED', False):
+            return True
+
         fattributes = config.get('FEEDS_ATTRS', None)
         if fattributes is None or feedname not in fattributes:
             return False
@@ -73,79 +202,33 @@ class MMAuthenticatedFeedUser(MMAuthenticatedUser):
             return True
 
         uattributes = config.get('FEEDS_USERS_ATTRS', None)
-        if uattributes is None or self._id not in uattributes:
+        if uattributes is None or self._id[6:] not in uattributes:
             return False
-        tags = set(uattributes[self._id].get('tags', []))
+        tags = set(uattributes[self._id[6:]].get('tags', []))
 
         return len(tags.intersection(ftags)) != 0
 
 
-class MMAnonymousFeedUser(MMAuthenticatedUser):
-    def __init__(self, auth_enabled=False):
-        super(MMAnonymousFeedUser, self).__init__(_id=ANONYMOUS)
+def authenticated_user_factory(_id):
+    if _id.startswith('feeds/'):
+        return MMAuthenticatedFeedUser(_id=_id[6:])
 
-        self.auth_enabled = auth_enabled
+    if _id.startswith('admin/'):
+        return MMAuthenticatedAdminUser(_id=_id[6:])
 
-    def check_feed(self, feedname):
-        if not self.auth_enabled:
-            return True
+    if _id == ANONYMOUS:
+        return MMAnonynmousUser()
 
-        fattributes = config.get('FEEDS_ATTRS', None)
-        if fattributes is None or feedname not in fattributes:
-            return False
-        ftags = set(fattributes[feedname].get('tags', []))
-
-        if 'anonymous' in ftags:
-            return True
-
-        return False
-
-    def is_anonymous(self):
-        return True
+    raise RuntimeError('Unknown user_id prefix: {}'.format(_id))
 
 
-def _feeds_request_loader(request):
-    if not config.get('FEEDS_AUTH_ENABLED', False):
-        return MMAnonymousFeedUser(auth_enabled=False)
-
-    api_key = request.headers.get('Authorization')
-    if api_key is None:
-        return MMAnonymousFeedUser(auth_enabled=True)
-
-    api_key = api_key.replace('Basic', '', 1)
-
-    try:
-        api_key = base64.b64decode(api_key)
-    except TypeError:
-        return None
-
-    try:
-        user, password = api_key.split(':', 1)
-    except ValueError:
-        return None
-
-    if not config.get('FEEDS_USERS_DB').check_password(user, password):
-        if config.get('USERS_DB').check_password(user, password):
-            return MMAuthenticatedAdminUser(_id=user)
-
-        return None
-
-    return MMAuthenticatedFeedUser(_id=user)
+LOGIN_MANAGER = flask.ext.login.LoginManager()
+LOGIN_MANAGER.session_protection = None
+LOGIN_MANAGER.anonymous_user = MMAnonynmousUser
 
 
 @LOGIN_MANAGER.request_loader
 def request_loader(request):
-    # check if this is a feed request
-    if request.path.startswith('/taxii-'):
-        return _feeds_request_loader(request)
-
-    if request.path.startswith('/feeds/'):
-        return _feeds_request_loader(request)
-
-    # if auth is disabled, proceed
-    if not config.get('API_AUTH_ENABLED', True):
-        return MMAnonymousAdminUser()
-
     api_key = request.headers.get('Authorization')
     if api_key is None:
         return None
@@ -162,18 +245,30 @@ def request_loader(request):
     except ValueError:
         return None
 
-    if not config.get('USERS_DB').check_password(user, password):
-        return None
+    auth_user = check_feeds_user(user, password)
+    if auth_user is not None:
+        return auth_user
 
-    return MMAuthenticatedAdminUser(_id=user)
+    auth_user = check_admin_user(user, password)
+    if auth_user is not None:
+        return auth_user
+
+    return None
 
 
 @LOGIN_MANAGER.user_loader
 def user_loader(_id):
-    return MMAuthenticatedAdminUser(_id=_id)
+    return authenticated_user_factory(_id)
 
 
-def check_user(username, password):
+def check_feeds_user(username, password):
+    if not config.get('FEEDS_USERS_DB').check_password(username, password):
+        return None
+
+    return MMAuthenticatedFeedUser(_id=username)
+
+
+def check_admin_user(username, password):
     if not config.get('USERS_DB').check_password(username, password):
         return None
 
@@ -183,3 +278,8 @@ def check_user(username, password):
 @LOGIN_MANAGER.unauthorized_handler
 def unauthorized():
     return 'Unauthorized', 401
+
+
+def init_app(app):
+    app.config['REMEMBER_COOKIE_NAME'] = None  # to block remember cookie
+    LOGIN_MANAGER.init_app(app)

--- a/minemeld/flask/config.py
+++ b/minemeld/flask/config.py
@@ -15,19 +15,19 @@
 import os
 
 import gevent
-import logging
 
 import yaml
 import filelock
 import passlib.apache
 
 from . import utils
+from .logger import LOG
+
 
 CONFIG = {}
 API_CONFIG_PATH = None
 API_CONFIG_LOCK = None
 
-LOG = logging.getLogger(__name__)
 CONFIG_FILES_RE = '^(?:(?:[0-9]+.*\.yml)|(?:.*\.htpasswd))$'
 
 _AUTH_DBS = {
@@ -186,8 +186,6 @@ def _config_monitor(config_path):
 def init():
     global API_CONFIG_PATH
     global API_CONFIG_LOCK
-
-    logging.basicConfig(level=logging.DEBUG)
 
     config_path = os.environ.get('MM_CONFIG', None)
     if config_path is None:

--- a/minemeld/flask/feedredis.py
+++ b/minemeld/flask/feedredis.py
@@ -12,28 +12,27 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import logging
 import re
 import cStringIO
 
-from flask import request, jsonify, Response, stream_with_context, Blueprint
-from flask.ext.login import login_required, current_user
+from flask import request, jsonify, Response, stream_with_context
+from flask.ext.login import current_user
 
 from .redisclient import SR
 from .mmrpc import MMMaster
+from .aaa import MMBlueprint
+from .logger import LOG
 
 
 __all__ = ['BLUEPRINT']
 
-
-LOG = logging.getLogger(__name__)
 
 FEED_INTERVAL = 100
 _PROTOCOL_RE = re.compile('^(?:[a-z]+:)*//')
 _INVALID_TOKEN_RE = re.compile('(?:[^\./+=\?&]+\*[^\./+=\?&]*)|(?:[^\./+=\?&]*\*[^\./+=\?&]+)')
 
 
-BLUEPRINT = Blueprint('feeds', __name__, url_prefix='/feeds')
+BLUEPRINT = MMBlueprint('feeds', __name__, url_prefix='/feeds')
 
 
 def generate_panosurl_feed(feed, start, num, desc, value):
@@ -157,8 +156,7 @@ _FEED_FORMATS = {
 }
 
 
-@BLUEPRINT.route('/<feed>', methods=['GET'])
-@login_required
+@BLUEPRINT.route('/<feed>', methods=['GET'], feeds=True, read_write=False)
 def get_feed_content(feed):
     if not current_user.check_feed(feed):
         return 'Unauthorized', 401

--- a/minemeld/flask/jobs.py
+++ b/minemeld/flask/jobs.py
@@ -14,7 +14,6 @@
 
 import os
 import uuid
-import logging
 import tempfile
 import subprocess
 import shutil
@@ -27,16 +26,15 @@ import psutil
 import werkzeug.local
 import gevent
 from gevent.subprocess import Popen
-
 from flask import g
+
 from . import REDIS_URL
 from . import config
+from .logger import LOG
 
 
 __all__ = ['init_app', 'JOBS_MANAGER']
 
-
-LOG = logging.getLogger(__name__)
 
 REDIS_CP = redis.ConnectionPool.from_url(
     REDIS_URL,

--- a/minemeld/flask/jobsapi.py
+++ b/minemeld/flask/jobsapi.py
@@ -14,32 +14,28 @@
 
 import os
 import os.path
-import logging
 
-from flask import send_from_directory, Blueprint, jsonify
-from flask.ext.login import login_required
+from flask import send_from_directory, jsonify
 
 from .jobs import JOBS_MANAGER
+from .aaa import MMBlueprint
+from .logger import LOG
 
 
 __all__ = ['BLUEPRINT']
 
 
-LOG = logging.getLogger(__name__)
-
-BLUEPRINT = Blueprint('jobs', __name__, url_prefix='/jobs')
+BLUEPRINT = MMBlueprint('jobs', __name__, url_prefix='/jobs')
 
 
-@BLUEPRINT.route('/<job_group>', methods=['GET'])
-@login_required
+@BLUEPRINT.route('/<job_group>', methods=['GET'], read_write=False)
 def get_jobs(job_group):
     jobs = JOBS_MANAGER.get_jobs(job_group)
 
     return jsonify(result=jobs)
 
 
-@BLUEPRINT.route('/<job_group>/<jobid>', methods=['GET'])
-@login_required
+@BLUEPRINT.route('/<job_group>/<jobid>', methods=['GET'], read_write=False)
 def get_job(job_group, jobid):
     jobs = JOBS_MANAGER.get_jobs(job_group)
     if jobid not in jobs:
@@ -48,8 +44,7 @@ def get_job(job_group, jobid):
     return jsonify(result=jobs[jobid])
 
 
-@BLUEPRINT.route('/<job_group>/<jobid>/log', methods=['GET'])
-@login_required
+@BLUEPRINT.route('/<job_group>/<jobid>/log', methods=['GET'], read_write=False)
 def get_job_log(job_group, jobid):
     jobs = JOBS_MANAGER.get_jobs(job_group)
     if jobid not in jobs:

--- a/minemeld/flask/logger.py
+++ b/minemeld/flask/logger.py
@@ -1,0 +1,75 @@
+import logging
+import json
+
+from flask import current_app
+
+# [2017-01-16 20:32:07 +0000] [15997] [INFO]
+LOG_FORMAT = '[%(asctime)s] [%(process)d] [%(levelname)s] %(message)s'
+LOG_DATE_FORMAT = '%Y-%m-%d %H:%M:%S %Z'
+
+
+class MMLogger(object):
+    def __init__(self):
+        self.system_logger = logging.getLogger('minemeld.api')
+        self._init_logger(self.system_logger)
+
+        self.system_logger.info('MMLogger started')
+
+    def init_app(self, app):
+        del app.logger.handlers[:]
+
+        self._init_logger(app.logger)
+
+    def _init_logger(self, logger):
+        logger.propagate = False
+        logger.setLevel(logging.DEBUG)
+
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter(
+            fmt=LOG_FORMAT,
+            datefmt=LOG_DATE_FORMAT
+        ))
+        logger.addHandler(handler)
+
+    def debug(self, *args, **kwargs):
+        if current_app:
+            current_app.logger.debug(*args, **kwargs)
+        else:
+            self.system_logger.debug(*args, **kwargs)
+
+    def info(self, *args, **kwargs):
+        if current_app:
+            current_app.logger.info(*args, **kwargs)
+        else:
+            self.system_logger.info(*args, **kwargs)
+
+    def warning(self, *args, **kwargs):
+        if current_app:
+            current_app.logger.warning(*args, **kwargs)
+        else:
+            self.system_logger.warning(*args, **kwargs)
+
+    def error(self, *args, **kwargs):
+        if current_app:
+            current_app.logger.error(*args, **kwargs)
+        else:
+            self.system_logger.error(*args, **kwargs)
+
+    def critical(self, *args, **kwargs):
+        if current_app:
+            current_app.logger.critical(*args, **kwargs)
+        else:
+            self.system_logger.critical(*args, **kwargs)
+
+    def exception(self, *args, **kwargs):
+        if current_app:
+            current_app.logger.exception(*args, **kwargs)
+        else:
+            self.system_logger.exception(*args, **kwargs)
+
+    def audit(self, user_id, action_name, params, msg=None):
+        audit_params = dict(user=user_id, action=action_name, params=params, msg=msg)
+        self.info('AUDIT - {}'.format(json.dumps(audit_params)))
+
+
+LOG = MMLogger()

--- a/minemeld/flask/loginapi.py
+++ b/minemeld/flask/loginapi.py
@@ -12,23 +12,20 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import logging
-
-from flask import request, jsonify, Blueprint
+from flask import request, jsonify
 import flask.ext.login
 
 from . import aaa
+from .logger import LOG
 
 
 __all__ = ['BLUEPRINT']
 
 
-LOG = logging.getLogger(__name__)
-
-BLUEPRINT = Blueprint('login', __name__, url_prefix='')
+BLUEPRINT = aaa.MMBlueprint('login', __name__, url_prefix='')
 
 
-@BLUEPRINT.route('/login', methods=['GET', 'POST'])
+@BLUEPRINT.route('/login', methods=['GET', 'POST'], login_required=False, read_write=False)
 def login():
     username = request.values.get('u')
     if username is None:
@@ -38,7 +35,7 @@ def login():
     if password is None:
         return jsonify(error='Missing password'), 400
 
-    user = aaa.check_user(username, password)
+    user = aaa.check_admin_user(username, password)
     if user is None:
         return jsonify(error="Wrong credentials"), 401
 
@@ -46,7 +43,7 @@ def login():
     return 'OK'
 
 
-@BLUEPRINT.route('/logout', methods=['GET'])
+@BLUEPRINT.route('/logout', methods=['GET'], login_required=False, read_write=False)
 def logout():
     flask.ext.login.logout_user()
     return 'OK'

--- a/minemeld/flask/logsapi.py
+++ b/minemeld/flask/logsapi.py
@@ -12,24 +12,20 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import logging
-
-from flask import send_from_directory, Blueprint, jsonify
-from flask.ext.login import login_required
+from flask import send_from_directory, jsonify
 
 from . import config
+from .aaa import MMBlueprint
+from .logger import LOG
 
 
 __all__ = ['BLUEPRINT']
 
 
-LOG = logging.getLogger(__name__)
-
-BLUEPRINT = Blueprint('logs', __name__, url_prefix='/logs')
+BLUEPRINT = MMBlueprint('logs', __name__, url_prefix='/logs')
 
 
-@BLUEPRINT.route('/minemeld-engine.log', methods=['GET'])
-@login_required
+@BLUEPRINT.route('/minemeld-engine.log', methods=['GET'], read_write=True)
 def get_minemeld_engine_log():
     log_directory = config.get('MINEMELD_LOG_DIRECTORY_PATH', None)
     if log_directory is None:
@@ -38,8 +34,7 @@ def get_minemeld_engine_log():
     return send_from_directory(log_directory, 'minemeld-engine.log', as_attachment=True)
 
 
-@BLUEPRINT.route('/minemeld-web.log', methods=['GET'])
-@login_required
+@BLUEPRINT.route('/minemeld-web.log', methods=['GET'], read_write=True)
 def get_minemeld_web_log():
     log_directory = config.get('MINEMELD_LOG_DIRECTORY_PATH', None)
     if log_directory is None:

--- a/minemeld/flask/mmrpc.py
+++ b/minemeld/flask/mmrpc.py
@@ -1,6 +1,5 @@
 # amqp connection
 import json
-import logging
 
 import gevent
 import gevent.event
@@ -14,12 +13,10 @@ import minemeld.comm
 from minemeld.mgmtbus import MGMTBUS_PREFIX
 
 from . import config
+from .logger import LOG
 
 
 __all__ = ['init_app', 'MMMaster', 'MMRpcClient', 'MMStateFanout']
-
-
-LOG = logging.getLogger(__name__)
 
 
 class _MMMasterConnection(object):
@@ -79,7 +76,6 @@ class _MMRpcClient(object):
 
     def send_raw_cmd(self, target, method, params={}, timeout=10):
         self._open_channel()
-        LOG.debug('MMRpcClient channel open')
 
         return self.comm.send_rpc(target, method, params, timeout=timeout)
 

--- a/minemeld/flask/prototypeapi.py
+++ b/minemeld/flask/prototypeapi.py
@@ -12,31 +12,28 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import logging
-
 import os
 import os.path
 
 import yaml
 import filelock
-from flask import jsonify, request, Blueprint
-from flask.ext.login import login_required
+from flask import jsonify, request
 
 import minemeld.loader
 
 from . import config
 from .utils import running_config, committed_config
+from .aaa import MMBlueprint
+from .logger import LOG
 
 
 __all__ = ['BLUEPRINT']
 
 
-LOG = logging.getLogger(__name__)
-
 PROTOTYPE_ENV = 'MINEMELD_PROTOTYPE_PATH'
 LOCAL_PROTOTYPE_PATH = 'MINEMELD_LOCAL_PROTOTYPE_PATH'
 
-BLUEPRINT = Blueprint('prototype', __name__, url_prefix='')
+BLUEPRINT = MMBlueprint('prototype', __name__, url_prefix='')
 
 PROTOTYPE_PATHS = None
 
@@ -104,8 +101,7 @@ def _local_library_path(prototypename):
     return library_path, prototype
 
 
-@BLUEPRINT.route('/prototype', methods=['GET'])
-@login_required
+@BLUEPRINT.route('/prototype', methods=['GET'], read_write=False)
 def list_prototypes():
     paths = _prototype_paths()
 
@@ -137,8 +133,7 @@ def list_prototypes():
     return jsonify(result=prototypes)
 
 
-@BLUEPRINT.route('/prototype/<prototypename>', methods=['GET'])
-@login_required
+@BLUEPRINT.route('/prototype/<prototypename>', methods=['GET'], read_write=False)
 def get_prototype(prototypename):
     toks = prototypename.split('.', 1)
     if len(toks) != 2:
@@ -203,8 +198,7 @@ def get_prototype(prototypename):
         return jsonify(result=result), 200
 
 
-@BLUEPRINT.route('/prototype/<prototypename>', methods=['POST'])
-@login_required
+@BLUEPRINT.route('/prototype/<prototypename>', methods=['POST'], read_write=True)
 def add_local_prototype(prototypename):
     AUTHOR_ = 'minemeld-web'
     DESCRIPTION_ = 'Local prototype library managed via MineMeld WebUI'
@@ -276,8 +270,7 @@ def add_local_prototype(prototypename):
     return jsonify(result='OK'), 200
 
 
-@BLUEPRINT.route('/prototype/<prototypename>', methods=['DELETE'])
-@login_required
+@BLUEPRINT.route('/prototype/<prototypename>', methods=['DELETE'], read_write=True)
 def delete_local_prototype(prototypename):
     try:
         library_path, prototype = _local_library_path(prototypename)

--- a/minemeld/flask/redisclient.py
+++ b/minemeld/flask/redisclient.py
@@ -1,17 +1,16 @@
 import os
-import logging
 
 import redis
 import werkzeug.local
 
 from flask import g
+
 from . import REDIS_URL
+from .logger import LOG
 
 
 __all__ = ['init_app', 'SR']
 
-
-LOG = logging.getLogger(__name__)
 
 REDIS_CP = redis.ConnectionPool.from_url(
     REDIS_URL,
@@ -31,7 +30,7 @@ def teardown(exception):
     SR = getattr(g, '_redis_client', None)
     if SR is not None:
         g._redis_client = None
-        LOG.info(
+        LOG.debug(
             'redis connection pool: in use: {} available: {}'.format(
                 len(REDIS_CP._in_use_connections),
                 len(REDIS_CP._available_connections)

--- a/minemeld/flask/session.py
+++ b/minemeld/flask/session.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 import os
-import logging
 from datetime import timedelta
 from uuid import uuid4
 
@@ -22,7 +21,8 @@ import redis
 import werkzeug.datastructures
 import flask.sessions
 
-LOG = logging.getLogger(__name__)
+from .logger import LOG
+
 
 SESSION_EXPIRATION_ENV = 'SESSION_EXPIRATION'
 DEFAULT_SESSION_EXPIRATION = 10
@@ -61,8 +61,8 @@ class RedisSessionInterface(flask.sessions.SessionInterface):
         return timedelta(minutes=10)
 
     def open_session(self, app, request):
-        LOG.info(
-            'redis connection pool: in use: {} available: {}'.format(
+        LOG.debug(
+            'redis session connection pool: in use: {} available: {}'.format(
                 len(self.redis.connection_pool._in_use_connections),
                 len(self.redis.connection_pool._available_connections)
             )

--- a/minemeld/flask/taxiicollmgmt.py
+++ b/minemeld/flask/taxiicollmgmt.py
@@ -12,32 +12,30 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import logging
 import re
 
 import libtaxii
 import libtaxii.messages_11
 import libtaxii.constants
 
-from flask import request, Blueprint
-from flask.ext.login import login_required, current_user
+from flask import request
+from flask.ext.login import current_user
 
 from . import config
 from .taxiiutils import taxii_check, taxii_make_response, get_taxii_feeds
+from .aaa import MMBlueprint
+from .logger import LOG
 
 
 __all__ = ['BLUEPRINT']
 
 
-LOG = logging.getLogger(__name__)
-
 HOST_RE = re.compile('^[a-zA-Z\d-]{1,63}(?:\.[a-zA-Z\d-]{1,63})*(?::[0-9]{1,5})*$')
 
-BLUEPRINT = Blueprint('taxiicollmgmt', __name__, url_prefix='')
+BLUEPRINT = MMBlueprint('taxiicollmgmt', __name__, url_prefix='')
 
 
-@BLUEPRINT.route('/taxii-collection-management-service', methods=['POST'])
-@login_required
+@BLUEPRINT.route('/taxii-collection-management-service', methods=['POST'], feeds=True, read_write=False)
 @taxii_check
 def taxii_collection_mgmt_service():
     taxii_feeds = get_taxii_feeds()

--- a/minemeld/flask/taxiidiscovery.py
+++ b/minemeld/flask/taxiidiscovery.py
@@ -12,26 +12,25 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import logging
 import re
 
 import libtaxii
 import libtaxii.messages_11
 import libtaxii.constants
 
-from flask import request, Blueprint
-from flask.ext.login import login_required, current_user
+from flask import request
+from flask.ext.login import current_user
 
 from . import config
 from .taxiiutils import get_taxii_feeds, taxii_check, taxii_make_response
+from .aaa import MMBlueprint
+from .logger import LOG
 
 
 __all__ = ['BLUEPRINT']
 
 
-LOG = logging.getLogger(__name__)
-
-BLUEPRINT = Blueprint('taxiidiscovery', __name__, url_prefix='')
+BLUEPRINT = MMBlueprint('taxiidiscovery', __name__, url_prefix='')
 
 HOST_RE = re.compile('^[a-zA-Z\d-]{1,63}(?:\.[a-zA-Z\d-]{1,63})*(?::[0-9]{1,5})*$')
 
@@ -51,8 +50,7 @@ _SERVICE_INSTANCES = [
 ]
 
 
-@BLUEPRINT.route('/taxii-discovery-service', methods=['POST'])
-@login_required
+@BLUEPRINT.route('/taxii-discovery-service', methods=['POST'], feeds=True, read_write=False)
 @taxii_check
 def taxii_discovery_service():
     taxii_feeds = get_taxii_feeds()

--- a/minemeld/flask/taxiiutils.py
+++ b/minemeld/flask/taxiiutils.py
@@ -12,15 +12,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import logging
 import functools
 
 from flask import request
 from flask import make_response
 
 from .mmrpc import MMMaster
-
-LOG = logging.getLogger(__name__)
+from .logger import LOG
 
 
 def taxii_make_response(m11):

--- a/minemeld/flask/tracedapi.py
+++ b/minemeld/flask/tracedapi.py
@@ -12,13 +12,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import logging
 import uuid
 
-from flask import request, jsonify, Blueprint
-from flask.ext.login import login_required
+from flask import request, jsonify
 
 from .mmrpc import MMRpcClient
+from .aaa import MMBlueprint
+from .logger import LOG
 
 import minemeld.traced
 
@@ -26,13 +26,10 @@ import minemeld.traced
 __all__ = ['BLUEPRINT']
 
 
-LOG = logging.getLogger(__name__)
-
-BLUEPRINT = Blueprint('traced', __name__, url_prefix='/traced')
+BLUEPRINT = MMBlueprint('traced', __name__, url_prefix='/traced')
 
 
-@BLUEPRINT.route('/query')
-@login_required
+@BLUEPRINT.route('/query', read_write=False)
 def traced_query():
     query_uuid = request.args.get('uuid', None)
     if query_uuid is None:
@@ -77,8 +74,7 @@ def traced_query():
 
 
 @BLUEPRINT.route('/query/<query_uuid>/kill')
-@login_required
-def traced_kill_query(query_uuid):
+def traced_kill_query(query_uuid, read_write=False):
     try:
         uuid.UUID(query_uuid)
     except ValueError:

--- a/minemeld/flask/utils.py
+++ b/minemeld/flask/utils.py
@@ -14,11 +14,8 @@
 
 import os
 import re
-import logging
 
 import yaml
-
-LOG = logging.getLogger(__name__)
 
 
 class DirSnapshot(object):

--- a/minemeld/flask/validateapi.py
+++ b/minemeld/flask/validateapi.py
@@ -12,22 +12,19 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import logging
-
 import yaml
 
-from flask.ext.login import login_required
-from flask import jsonify, request, Blueprint
+from flask import jsonify, request
 
 import minemeld.ft.condition
+from .aaa import MMBlueprint
+from .logger import LOG
 
 
 __all__ = ['BLUEPRINT']
 
 
-LOG = logging.getLogger(__name__)
-
-BLUEPRINT = Blueprint('validate', __name__, url_prefix='/validate')
+BLUEPRINT = MMBlueprint('validate', __name__, url_prefix='/validate')
 
 
 def _return_validation_error(msg):
@@ -36,8 +33,7 @@ def _return_validation_error(msg):
     }), 400
 
 
-@BLUEPRINT.route('/syslogminerrule', methods=['POST'])
-@login_required
+@BLUEPRINT.route('/syslogminerrule', methods=['POST'], read_write=False)
 def validate_syslogminerrule():
     try:
         crule = request.data

--- a/tests/test_flask_aaa.py
+++ b/tests/test_flask_aaa.py
@@ -895,10 +895,10 @@ class MineMeldFlaskAAATests(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
 
         resp = self._taxii_discovery_request(username='user1', password='password2')
-        self.assertEqual(resp.status_code, 401)
+        self.assertEqual(resp.status_code, 200)
 
         resp = self._taxii_discovery_request(username='admin', password='password1')
-        self.assertEqual(resp.status_code, 401)
+        self.assertEqual(resp.status_code, 200)
 
         resp = self._taxii_collection_request()
         self.assertEqual(self._num_collections(resp), 1)
@@ -916,10 +916,10 @@ class MineMeldFlaskAAATests(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
 
         resp = self._taxii_collection_request(username='user1', password='password2')
-        self.assertEqual(resp.status_code, 401)
+        self.assertEqual(resp.status_code, 200)
 
         resp = self._taxii_collection_request(username='admin', password='password2')
-        self.assertEqual(resp.status_code, 401)
+        self.assertEqual(resp.status_code, 200)
 
     @mock.patch.dict('minemeld.flask.config.os.environ', {
         'MM_CONFIG': '.',
@@ -1051,10 +1051,10 @@ class MineMeldFlaskAAATests(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
 
         resp = self._taxii_discovery_request(username='user1', password='password2')
-        self.assertEqual(resp.status_code, 401)
+        self.assertEqual(resp.status_code, 200)
 
         resp = self._taxii_discovery_request(username='admin', password='password1')
-        self.assertEqual(resp.status_code, 401)
+        self.assertEqual(resp.status_code, 200)
 
         resp = self._taxii_collection_request()
         self.assertEqual(self._num_collections(resp), 1)
@@ -1073,10 +1073,10 @@ class MineMeldFlaskAAATests(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
 
         resp = self._taxii_collection_request(username='user1', password='password2')
-        self.assertEqual(resp.status_code, 401)
+        self.assertEqual(resp.status_code, 200)
 
         resp = self._taxii_collection_request(username='admin', password='password2')
-        self.assertEqual(resp.status_code, 401)
+        self.assertEqual(resp.status_code, 200)
 
     @mock.patch.dict('minemeld.flask.config.os.environ', {
         'MM_CONFIG': '.',
@@ -1338,10 +1338,10 @@ class MineMeldFlaskAAATests(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
 
         resp = self._taxii_poll_request('feed1', username='user1', password='password2')
-        self.assertEqual(resp.status_code, 401)
+        self.assertEqual(resp.status_code, 200)
 
         resp = self._taxii_poll_request('feed1', username='admin', password='password1')
-        self.assertEqual(resp.status_code, 401)
+        self.assertEqual(resp.status_code, 200)
 
     @mock.patch.dict('minemeld.flask.config.os.environ', {
         'MM_CONFIG': '.',
@@ -1391,7 +1391,7 @@ class MineMeldFlaskAAATests(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
 
         resp = self._taxii_poll_request('feed1', username='user1', password='password2')
-        self.assertEqual(resp.status_code, 401)
+        self.assertEqual(resp.status_code, 200)
 
         resp = self._taxii_poll_request('feed1', username='admin', password='password1')
-        self.assertEqual(resp.status_code, 401)
+        self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
## Motivation

Support for read_only and read_write admin roles to have better granularity on admin authorizations.

## Modifications

READ_WRITE authorization:
- Added a subclass of flask Blueprint that decorates view funcs with an auth check function and an audit log function
- Each view function of the API is now decorated with *read_write*, *login_required* and *feeds* additional keywords. Default are the strictest: *read_write*: True, *login_required*: True, *feeds*: False.
- Added support for new *READ_WRITE* config parameter. Value should be a comma separated list of user_ids to give read-write access to
- When *READ_WRITE* is set, only users in *READ_WRITE* are able to access routes with *read_write* flag. For everybody else the routes return a 403 error or 401, if a feed use tries to access an API endpoint.
- When *READ_WRITE* is not set, fallback to the old behavior where all the admin users have read-write access. Feed users still get a 401 from the API

Audit log:
- Every route with *read_write* set to True generates an AUDIT log in the logfile with format: *AUDIT - <audit log in JSON>*

## Result

Support for read-write admins and audit logs.

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>