### PR TITLE
Adds support for disk space checking

### DIFF
--- a/minemeld/flask/statusapi.py
+++ b/minemeld/flask/statusapi.py
@@ -20,6 +20,7 @@ import time
 
 from flask import Response, stream_with_context, jsonify, request
 
+from . import config
 from .mmrpc import MMMaster
 from .mmrpc import MMStateFanout
 from .mmrpc import MMRpcClient
@@ -135,11 +136,15 @@ def get_status_events():
 
 @BLUEPRINT.route('/system', methods=['GET'], read_write=False)
 def get_system_status():
+    data_path = config.get('MINEMELD_LOCAL_PATH', None)
+    if data_path is None:
+        jsonify(error={'message': 'MINEMELD_LOCAL_PATH not set'}), 500
+
     res = {}
     res['cpu'] = psutil.cpu_percent(interval=1, percpu=True)
     res['memory'] = psutil.virtual_memory().percent
     res['swap'] = psutil.swap_memory().percent
-    res['disk'] = psutil.disk_usage('/').percent
+    res['disk'] = psutil.disk_usage(data_path).percent
 
     return jsonify(result=res, timestamp=int(time.time()*1000))
 

--- a/minemeld/flask/supervisorapi.py
+++ b/minemeld/flask/supervisorapi.py
@@ -89,7 +89,8 @@ def service_status():
     for p in pinfo:
         process = {
             'statename': p['statename'],
-            'start': p['start']
+            'start': p['start'],
+            'children': None
         }
 
         try:
@@ -98,7 +99,6 @@ def service_status():
 
         except:
             LOG.exception("Error retrieving childen of %d" % p['pid'])
-            pass
 
         supervisorstate['processes'][p['name']] = process
 

--- a/minemeld/traced/main.py
+++ b/minemeld/traced/main.py
@@ -118,7 +118,8 @@ def main():
     trace_writer = minemeld.traced.writer.Writer(
         comm,
         store,
-        topic=config.get('topic', 'mbus:log')
+        topic=config.get('topic', 'mbus:log'),
+        config=config.get('writer', {})
     )
 
     query_processor = minemeld.traced.queryprocessor.QueryProcessor(

--- a/minemeld/traced/purge.py
+++ b/minemeld/traced/purge.py
@@ -23,6 +23,11 @@ def _parse_args():
         help='Dry run'
     )
     parser.add_argument(
+        '--all',
+        action='store_true',
+        help='Delete all traces'
+    )
+    parser.add_argument(
         'config',
         action='store',
         metavar='CONFIG',
@@ -164,7 +169,7 @@ def main():
             LOG.debug("Invalid table name: %s", t)
             continue
 
-        if d < oldest:
+        if d < oldest or args.all:
             LOG.info('Marking table %s for removal', t)
             tobe_removed.append(t)
 

--- a/minemeld/traced/writer.py
+++ b/minemeld/traced/writer.py
@@ -17,15 +17,45 @@ This module implements the writer class for logs
 """
 
 import logging
+
+import psutil
 import ujson
+import gevent
 import gevent.event
 
 LOG = logging.getLogger(__name__)
 
 
+class DiskSpaceMonitor(gevent.Greenlet):
+    def __init__(self, threshold, low_disk):
+        self._threshold = threshold
+        self._low_disk = low_disk
+
+        super(DiskSpaceMonitor, self).__init__()
+
+    def _run(self):
+        while True:
+            perc_used = psutil.disk_usage('.').percent
+
+            if perc_used >= self._threshold:
+                if not self._low_disk.is_set():
+                    self._low_disk.set()
+                    LOG.critical(
+                        'Disk space used above threshold ({}%), writing disabled'.format(self._threshold)
+                    )
+
+            else:
+                if self._low_disk.is_set():
+                    self._low_disk.clear()
+                    LOG.info('Disk space used below threshold, writing restored')
+
+            gevent.sleep(60)
+
+
 class Writer(object):
-    def __init__(self, comm, store, topic):
+    def __init__(self, comm, store, topic, config):
         self._stop = gevent.event.Event()
+        self._low_disk = gevent.event.Event()
 
         self.store = store
         self.comm = comm
@@ -36,8 +66,17 @@ class Writer(object):
             name='mbus:log:writer'
         )
 
+        self._disk_monitor_glet = DiskSpaceMonitor(
+            threshold=config.get('threshold', 90),
+            low_disk=self._low_disk
+        )
+        self._disk_monitor_glet.start()
+
     def log(self, timestamp, **kwargs):
         if self._stop.is_set():
+            return
+
+        if self._low_disk.is_set():
             return
 
         self.store.write(timestamp, ujson.dumps(kwargs))
@@ -49,3 +88,4 @@ class Writer(object):
             return
 
         self._stop.set()
+        self._disk_monitor_glet.kill()


### PR DESCRIPTION
- engine refuses to start if there is less than MM_DISK_SPACE_PER_NODE KB per configure node of available space. Default *MM_DISK_SPACE_PER_NODE* is 10K (= 10MB)
- engine every minute check for available disk space, if disk space falls below threshold an engine stop is triggered
- trace daemon checks every minute for available disk space, if available space falls below a threshold traces are not written
- a new API endpoint is provided to purge all the traces

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>