### PR TITLE
Adds process.command-line in schema

### DIFF
--- a/docs/schema-indicator-0-1.json
+++ b/docs/schema-indicator-0-1.json
@@ -20,7 +20,8 @@
                 "mutex",
                 "windows-registry-value",
                 "user-agent.fragment",
-                "file.name"
+                "file.name",
+                "process.command_line"
             ]
         },
         "direction": {


### PR DESCRIPTION
New indicator type introduced for process command lines.

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>