### PR TITLE
TAXII Client improvements

### DIFF
--- a/docs/schema-indicator-0-1.json
+++ b/docs/schema-indicator-0-1.json
@@ -21,7 +21,8 @@
                 "windows-registry-value",
                 "user-agent.fragment",
                 "file.name",
-                "process.command_line"
+                "process.command_line",
+                "email-addr"
             ]
         },
         "direction": {

--- a/minemeld/flask/__init__.py
+++ b/minemeld/flask/__init__.py
@@ -57,6 +57,7 @@ def create_app():
     from . import metricsapi  # noqa
     from . import feedredis  # noqa
     from . import configapi  # noqa
+    from . import configdataapi  # noqa
     from . import taxiidiscovery  # noqa
     from . import taxiicollmgmt  # noqa
     from . import taxiipoll  # noqa
@@ -77,6 +78,7 @@ def create_app():
     app.register_blueprint(statusapi.BLUEPRINT)
     app.register_blueprint(feedredis.BLUEPRINT)
     app.register_blueprint(configapi.BLUEPRINT)
+    app.register_blueprint(configdataapi.BLUEPRINT)
     app.register_blueprint(taxiidiscovery.BLUEPRINT)
     app.register_blueprint(taxiicollmgmt.BLUEPRINT)
     app.register_blueprint(taxiipoll.BLUEPRINT)

--- a/minemeld/flask/configdataapi.py
+++ b/minemeld/flask/configdataapi.py
@@ -191,7 +191,7 @@ class _CDataCertificate(_CDataUploadOnly):
 
 class _CDataPrivateKey(_CDataUploadOnly):
     def __init__(self, cpath, datafilename):
-        super(_CDataCertificate, self).__init__(
+        super(_CDataPrivateKey, self).__init__(
             extension='pem',
             cpath=cpath,
             datafilename=datafilename
@@ -224,9 +224,9 @@ def save_config_data(datafilename):
     if datafiletype == 'yaml':
         result = _CDataYaml(cpath, datafilename).create()
     elif datafiletype == 'cert':
-        _CDataCertificate(cpath, datafilename).create()
+        result = _CDataCertificate(cpath, datafilename).create()
     elif datafiletype == 'pkey':
-        _CDataPrivateKey(cpath, datafilename).create()
+        result = _CDataPrivateKey(cpath, datafilename).create()
     else:
         return jsonify(error=dict(message='Unknown data file type')), 400
 

--- a/minemeld/flask/configdataapi.py
+++ b/minemeld/flask/configdataapi.py
@@ -1,0 +1,263 @@
+#  Copyright 2015-present Palo Alto Networks, Inc
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os.path
+import os
+import shutil
+
+from tempfile import NamedTemporaryFile
+
+import yaml
+import filelock
+
+from flask import request, jsonify
+
+from .mmrpc import MMRpcClient
+from .aaa import MMBlueprint
+from .logger import LOG
+
+
+__all__ = ['BLUEPRINT']
+
+
+LOCK_TIMEOUT = 3000
+
+
+BLUEPRINT = MMBlueprint('configdata', __name__, url_prefix='/config/data')
+
+
+def _safe_remove(path, g=None):
+    try:
+        os.remove(path)
+    except:
+        LOG.exception('Exception removing {}'.format(path))
+
+
+class _CDataYaml(object):
+    def __init__(self, cpath, datafilename):
+        self.cpath = cpath
+        self.datafilename = datafilename
+
+    def read(self):
+        fdfname = self.datafilename+'.yml'
+
+        lockfname = os.path.join(self.cpath, fdfname+'.lock')
+        lock = filelock.FileLock(lockfname)
+
+        os.listdir(self.cpath)
+        if fdfname not in os.listdir(self.cpath):
+            return jsonify(error={
+                'message': 'Unknown config data file'
+            }), 400
+
+        try:
+            with lock.acquire(timeout=10):
+                with open(os.path.join(self.cpath, fdfname), 'r') as f:
+                    result = yaml.safe_load(f)
+
+        except Exception as e:
+            return jsonify(error={
+                'message': 'Error loading config data file: %s' % str(e)
+            }), 500
+
+        return jsonify(result=result)
+
+    def create(self):
+        tdir = os.path.dirname(os.path.join(self.cpath, self.datafilename))
+
+        if not os.path.samefile(self.cpath, tdir):
+            return jsonify(error={'msg': 'Wrong config data filename'}), 400
+
+        fdfname = os.path.join(self.cpath, self.datafilename+'.yml')
+
+        lockfname = fdfname+'.lock'
+        lock = filelock.FileLock(lockfname)
+
+        try:
+            body = request.get_json()
+        except Exception as e:
+            return jsonify(error={'message': str(e)}), 400
+
+        try:
+            with lock.acquire(timeout=10):
+                with open(fdfname, 'w') as f:
+                    yaml.safe_dump(body, stream=f)
+        except Exception as e:
+            return jsonify(error={
+                'message': str(e)
+            }), 500
+
+    def append(self):
+        tdir = os.path.dirname(os.path.join(self.cpath, self.datafilename))
+
+        if not os.path.samefile(self.cpath, tdir):
+            return jsonify(error={'msg': 'Wrong config data filename'}), 400
+
+        cdfname = os.path.join(self.cpath, self.datafilename+'.yml')
+
+        lockfname = cdfname+'.lock'
+        lock = filelock.FileLock(lockfname)
+
+        try:
+            with lock.acquire(timeout=10):
+                if not os.path.isfile(cdfname):
+                    config_data_file = []
+                else:
+                    with open(cdfname, 'r') as f:
+                        config_data_file = yaml.safe_load(f)
+
+                if type(config_data_file) != list:
+                    raise RuntimeError('Config data file is not a list')
+
+                body = request.get_json()
+                if body is None:
+                    return jsonify(error={
+                        'message': 'No record in request'
+                    }), 400
+
+                config_data_file.append(body)
+
+                with open(cdfname, 'w') as f:
+                    yaml.safe_dump(config_data_file, stream=f)
+
+        except Exception as e:
+            return jsonify(error={
+                'message': 'Error appending to config data file: %s' % str(e)
+            }), 500
+
+
+class _CDataUploadOnly(object):
+    def __init__(self, extension, cpath, datafilename):
+        self.extension = extension
+        self.cpath = cpath
+        self.datafilename = datafilename
+
+    def read(self):
+        fdfname = '{}.{}'.format(self.datafilename, self.extension)
+
+        os.listdir(self.cpath)
+        if fdfname not in os.listdir(self.cpath):
+            return jsonify(error={
+                'message': 'Unknown config data file'
+            }), 400
+
+        return jsonify(result='ok')
+
+    def create(self):
+        tdir = os.path.dirname(os.path.join(self.cpath, self.datafilename))
+
+        if not os.path.samefile(self.cpath, tdir):
+            return jsonify(error={'msg': 'Wrong config data filename'}), 400
+
+        fdfname = os.path.join(self.cpath, '{}.{}'.format(self.datafilename, self.extension))
+
+        if 'file' not in request.files:
+            return jsonify(error={'messsage': 'No file'}), 400
+
+        file = request.files['file']
+        if file.filename == '':
+            return jsonify(error={'message': 'No file'}), 400
+
+        tf = NamedTemporaryFile(prefix='mm-extension-upload', delete=False)
+        try:
+            file.save(tf)
+            tf.close()
+
+            shutil.move(tf.name, fdfname)
+
+        finally:
+            _safe_remove(tf.name)
+
+
+class _CDataCertificate(_CDataUploadOnly):
+    def __init__(self, cpath, datafilename):
+        super(_CDataCertificate, self).__init__(
+            extension='crt',
+            cpath=cpath,
+            datafilename=datafilename
+        )
+
+
+class _CDataPrivateKey(_CDataUploadOnly):
+    def __init__(self, cpath, datafilename):
+        super(_CDataCertificate, self).__init__(
+            extension='pem',
+            cpath=cpath,
+            datafilename=datafilename
+        )
+
+
+# API for working with side configs and dynamic data files
+@BLUEPRINT.route('/<datafilename>', methods=['GET'], read_write=False)
+def get_config_data(datafilename):
+    cpath = os.path.dirname(os.environ.get('MM_CONFIG'))
+
+    datafiletype = request.values.get('t', 'yaml')
+
+    if datafiletype == 'yaml':
+        return _CDataYaml(cpath, datafilename).read()
+    elif datafiletype == 'cert':
+        return _CDataCertificate(cpath, datafilename).read()
+    elif datafiletype == 'pkey':
+        return _CDataPrivateKey(cpath, datafilename).read()
+
+    return jsonify(error=dict(message='Unknown data file type')), 400
+
+
+@BLUEPRINT.route('/<datafilename>', methods=['PUT'], read_write=True)
+def save_config_data(datafilename):
+    cpath = os.path.dirname(os.environ.get('MM_CONFIG'))
+
+    datafiletype = request.values.get('t', 'yaml')
+
+    if datafiletype == 'yaml':
+        result = _CDataYaml(cpath, datafilename).create()
+    elif datafiletype == 'cert':
+        _CDataCertificate(cpath, datafilename).create()
+    elif datafiletype == 'pkey':
+        _CDataPrivateKey(cpath, datafilename).create()
+    else:
+        return jsonify(error=dict(message='Unknown data file type')), 400
+
+    if result is None:
+        hup = request.args.get('h', None)
+        if hup is not None:
+            MMRpcClient.send_cmd(hup, 'hup', {'source': 'minemeld-web'})
+
+        return jsonify(result='ok'), 200
+
+    return result
+
+
+@BLUEPRINT.route('/<datafilename>/append', methods=['POST'], read_write=True)
+def append_config_data(datafilename):
+    cpath = os.path.dirname(os.environ.get('MM_CONFIG'))
+
+    cpath = os.path.dirname(os.environ.get('MM_CONFIG'))
+
+    datafiletype = request.values.get('t', 'yaml')
+
+    if datafiletype == 'yaml':
+        result = _CDataYaml(cpath, datafilename).append()
+    else:
+        return jsonify(error=dict(message='Unknown data file type')), 400
+
+    if result is None:
+        hup = request.args.get('h', None)
+        if hup is not None:
+            MMRpcClient.send_cmd(hup, 'hup', {'source': 'minemeld-web'})
+
+        return jsonify(result='ok'), 200
+
+    return result

--- a/minemeld/ft/taxii.py
+++ b/minemeld/ft/taxii.py
@@ -85,14 +85,14 @@ class TaxiiClient(basepoller.BasePollerFT):
         if isinstance(self.key_file, bool) and self.key_file:
             self.key_file = os.path.join(
                 os.environ['MM_CONFIG_DIR'],
-                '%s-key.pem' % self.name
+                '%s.pem' % self.name
             )
 
         self.cert_file = self.config.get('cert_file', None)
         if isinstance(self.cert_file, bool) and self.cert_file:
             self.cert_file = os.path.join(
                 os.environ['MM_CONFIG_DIR'],
-                '%s-key.pem' % self.name
+                '%s.crt' % self.name
             )
 
         self.side_config_path = self.config.get('side_config', None)
@@ -186,12 +186,14 @@ class TaxiiClient(basepoller.BasePollerFT):
         up = urlparse.urlparse(self.discovery_service)
         hostname = up.hostname
         path = up.path
+        port = up.port
 
         resp = tc.call_taxii_service2(
             hostname,
             path,
             libtaxii.constants.VID_TAXII_XML_11,
-            request
+            request,
+            port=port
         )
 
         tm = libtaxii.get_message_from_http_response(resp, msg_id)
@@ -219,12 +221,14 @@ class TaxiiClient(basepoller.BasePollerFT):
         up = urlparse.urlparse(self.collection_mgmt_service)
         hostname = up.hostname
         path = up.path
+        port = up.port
 
         resp = tc.call_taxii_service2(
             hostname,
             path,
             libtaxii.constants.VID_TAXII_XML_11,
-            request
+            request,
+            port=port
         )
 
         tm = libtaxii.get_message_from_http_response(resp, msg_id)
@@ -273,12 +277,14 @@ class TaxiiClient(basepoller.BasePollerFT):
         up = urlparse.urlparse(self.poll_service)
         hostname = up.hostname
         path = up.path
+        port = up.port
 
         resp = tc.call_taxii_service2(
             hostname,
             path,
             libtaxii.constants.VID_TAXII_XML_11,
-            request
+            request,
+            port=port
         )
 
         return libtaxii.get_message_from_http_response(resp, msg_id)
@@ -305,12 +311,14 @@ class TaxiiClient(basepoller.BasePollerFT):
         up = urlparse.urlparse(self.poll_service)
         hostname = up.hostname
         path = up.path
+        port = up.port
 
         resp = tc.call_taxii_service2(
             hostname,
             path,
             libtaxii.constants.VID_TAXII_XML_11,
-            request
+            request,
+            port
         )
 
         tm = libtaxii.get_message_from_http_response(resp, msg_id)
@@ -678,6 +686,38 @@ class TaxiiClient(basepoller.BasePollerFT):
             os.remove(side_config_path)
         except:
             pass
+
+        cert_path = None
+        if config is not None:
+            cert_path = config.get('cert_file', None)
+
+            if isinstance(cert_path, bool) and cert_path:
+                cert_path = os.path.join(
+                    os.environ['MM_CONFIG_DIR'],
+                    '{}.crt'.format(name)
+                )
+
+            if cert_path is not None:
+                try:
+                    os.remove(cert_path)
+                except:
+                    pass
+
+        key_path = None
+        if config is not None:
+            key_path = config.get('key_file', None)
+
+            if isinstance(key_path, bool) and key_path:
+                key_path = os.path.join(
+                    os.environ['MM_CONFIG_DIR'],
+                    '{}.pem'.format(name)
+                )
+
+            if key_path is not None:
+                try:
+                    os.remove(key_path)
+                except:
+                    pass
 
 
 def _stix_ip_observable(namespace, indicator, value):

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ antlr4-python2-runtime==4.5.2
 jmespath==0.7.1
 click==4.1
 pan-python==0.10.0
-stix==1.1.1.5
+stix==1.1.1.6
 cybox==2.1.0.12
 libtaxii==1.1.107
 pytz==2015.4


### PR DESCRIPTION
## Motivation

Some TAXII servers requires client cert authentication. This was available on the engine but not exposed on the WebUI. This commit adds support for client cert auth on the WebUI and improves the TAXII Client code.

## Modifications

- adds API to upload certificates and private keys for specific nodes
- improves support for client auth (both cert and credentials) inside TAXIIClient
- adds support for non standard port in TAXIIClient (Fixes #173)
- adds support for subscription_id in TAXIIClient
- adds support for DHS AIS marking in TAXIIClient

## Result

Better interoperability with 3rd party TAXII Servers