### PR TITLE
Adds support minemeld webui extensions

### DIFF
--- a/minemeld/extensions/manager.py
+++ b/minemeld/extensions/manager.py
@@ -81,7 +81,8 @@ def _activated_extensions():
         minemeld.loader.MM_NODES_GCS_ENTRYPOINT,
         minemeld.loader.MM_NODES_VALIDATORS_ENTRYPOINT,
         minemeld.loader.MM_PROTOTYPES_ENTRYPOINT,
-        minemeld.loader.MM_API_ENTRYPOINT
+        minemeld.loader.MM_API_ENTRYPOINT,
+        minemeld.loader.MM_WEBUI_ENTRYPOINT
     )
 
     activated_extensions = {}

--- a/minemeld/flask/aaa.py
+++ b/minemeld/flask/aaa.py
@@ -27,6 +27,16 @@ ANONYMOUS = 'mm-anonymous'
 
 
 class MMBlueprint(Blueprint):
+    def __init__(self, *args, **kwargs):
+        super(MMBlueprint, self).__init__(*args, **kwargs)
+
+        self.send_static_file = self._login_required(
+            super(MMBlueprint, self).send_static_file,
+            login_required=True,
+            read_write=False,
+            feeds=False
+        )
+
     def _audit(self, f, audit_required):
         if not audit_required:
             return f

--- a/minemeld/flask/prototypeapi.py
+++ b/minemeld/flask/prototypeapi.py
@@ -15,6 +15,7 @@
 import sys
 import os
 import os.path
+import json
 
 import yaml
 import filelock

--- a/minemeld/loader.py
+++ b/minemeld/loader.py
@@ -13,6 +13,7 @@ MM_NODES_GCS_ENTRYPOINT = 'minemeld_nodes_gcs'
 MM_NODES_VALIDATORS_ENTRYPOINT = 'minemeld_nodes_validators'
 MM_PROTOTYPES_ENTRYPOINT = 'minemeld_prototypes'
 MM_API_ENTRYPOINT = 'minemeld_api'
+MM_WEBUI_ENTRYPOINT = 'minemeld_webui'
 
 MMEntryPoint = namedtuple(
     'MMEntryPoint',

--- a/minemeld/run/config.py
+++ b/minemeld/run/config.py
@@ -35,6 +35,13 @@ import minemeld.loader
 __all__ = ['load_config', 'validate_config', 'resolve_prototypes']
 
 
+# disables construction of timestamp objects
+yaml.SafeLoader.add_constructor(
+    u'tag:yaml.org,2002:timestamp',
+    yaml.SafeLoader.construct_yaml_str
+)
+
+
 LOG = logging.getLogger(__name__)
 
 COMMITTED_CONFIG = 'committed-config.yml'


### PR DESCRIPTION
## Motivation

Extensions provide a mechanism to extend MineMeld with custom nodes. Currently extension can only provide new nodes, new API endpoints and new prototypes, what is missing is a way to extend WebUI to provide a proper UI for the new nodes. This commit adds support for WebUI extensions.

## Modifications

- added a new entrypoint for WebUI extension. The new entry point points to a flask blueprint serving static files with the UI extension. 

## Result

Extensions can now also add new features to the WebUI.

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>