### PR TITLE
Fixes bug in activation of extensions downloaded via git

### DIFF
--- a/minemeld/extensions/manager.py
+++ b/minemeld/extensions/manager.py
@@ -1,3 +1,4 @@
+import sys
 import os
 import os.path
 import json
@@ -19,7 +20,8 @@ __all__ = [
     'activated_extensions',
     'installed_extensions',
     'extensions',
-    'freeze'
+    'freeze',
+    'load_frozen_paths'
 ]
 
 
@@ -315,3 +317,15 @@ def freeze(installation_dir):
             _freeze.append('-e {}'.format(e.path))
 
     return _freeze
+
+
+def load_frozen_paths(freeze_file):
+    for l in freeze_file:
+        l = l.strip()
+        if not l.startswith('-e '):
+            continue
+
+        _, epath = l.split(' ', 1)
+        if epath not in sys.path:
+            LOG.info('Extension path {!r} not in sys.path, adding'.format(epath))
+            sys.path.append(epath)

--- a/minemeld/flask/__init__.py
+++ b/minemeld/flask/__init__.py
@@ -79,6 +79,7 @@ def create_app():
     from . import jobsapi  # noqa
 
     configapi.init_app(app)
+    extensionsapi.init_app(app)
 
     app.register_blueprint(metricsapi.BLUEPRINT)
     app.register_blueprint(statusapi.BLUEPRINT)

--- a/minemeld/flask/extensionsapi.py
+++ b/minemeld/flask/extensionsapi.py
@@ -104,6 +104,20 @@ def _find_running_job(extension, jobs):
     return None
 
 
+def _load_frozen_paths():
+    library_directory = config.get('MINEMELD_LOCAL_LIBRARY_PATH', None)
+    if library_directory is None:
+        LOG.error('freeze not updated - MINEMELD_LOCAL_LIBRARY_PATH not set')
+        return
+
+    freeze_path = os.path.join(library_directory, 'freeze.txt')
+
+    freeze_lock = filelock.FileLock('{}.lock'.format(freeze_path))
+    with freeze_lock.acquire(timeout=30):
+        with open(freeze_path, 'r') as ff:
+            minemeld.extensions.load_frozen_paths(ff)
+
+
 def _update_freeze_file():
     library_directory = config.get('MINEMELD_LOCAL_LIBRARY_PATH', None)
     if library_directory is None:
@@ -502,3 +516,7 @@ def install_from_git():
         raise
 
     return jsonify(result=jobid)
+
+
+def init_app(app):
+    _load_frozen_paths()

--- a/minemeld/flask/logger.py
+++ b/minemeld/flask/logger.py
@@ -10,7 +10,7 @@ LOG_DATE_FORMAT = '%Y-%m-%d %H:%M:%S %Z'
 
 class MMLogger(object):
     def __init__(self):
-        self.system_logger = logging.getLogger('minemeld.api')
+        self.system_logger = logging.getLogger('minemeld')
         self._init_logger(self.system_logger)
 
         self.system_logger.info('MMLogger started')

--- a/minemeld/loader.py
+++ b/minemeld/loader.py
@@ -2,7 +2,7 @@ import logging
 
 import pip
 
-from pkg_resources import WorkingSet
+from pkg_resources import WorkingSet, _initialize_master_working_set
 from collections import namedtuple
 
 
@@ -22,7 +22,7 @@ MMEntryPoint = namedtuple(
 
 _ENTRYPOINT_GROUPS = {}
 
-_WS = WorkingSet()
+_WS = None
 
 
 def _installed_versions():
@@ -50,7 +50,13 @@ def _conflicts(requirements, installed):
 
 
 def _initialize_entry_point_group(entrypoint_group):
+    global _WS
+
     installed = _installed_versions()
+
+    if _WS is None:
+        _initialize_master_working_set()
+        _WS = WorkingSet()
 
     cache = {}
     result = {}
@@ -82,7 +88,7 @@ def _initialize_entry_point_group(entrypoint_group):
 def bump_workingset():
     global _WS, _ENTRYPOINT_GROUPS
 
-    _WS = WorkingSet()
+    _WS = None
     _ENTRYPOINT_GROUPS = {}
 
 


### PR DESCRIPTION
After an API restart, extensions downloaded via git are not shown as "activated". The problem is that the new API process inherits sys.path from the parent gunicorn that is not aware of the newly activated extensions.

A new function is defined in minemeld.extensions to verify that all the paths inside freeze.txt are available in sys.path. This function is called when extensions API are initialized.

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>