### PR TITLE
Change priority of prototypes

### DIFF
--- a/minemeld/flask/prototypeapi.py
+++ b/minemeld/flask/prototypeapi.py
@@ -65,7 +65,8 @@ def _prototype_paths():
                     sys.modules.pop(mmep.ep.module_name)
 
             ep = mmep.ep.load()
-            paths.append(ep())
+            # we add prototype paths in front, to let extensions override default protos
+            paths.insert(0, ep())
         except:
             LOG.exception('Exception loading paths from {}'.format(pname))
 

--- a/minemeld/run/config.py
+++ b/minemeld/run/config.py
@@ -482,7 +482,8 @@ def resolve_prototypes(config):
 
         try:
             ep = mmep.ep.load()
-            paths.append(ep())
+            # we add prototype paths in front, to let extensions override default protos
+            paths.insert(0, ep())
 
         except:
             LOG.exception(


### PR DESCRIPTION
## Motivation

There are scenarios where extension writers want to override prototypes included in the default library. Example: adapt the prototype config to a specific environment without changing the prototype names.

## Modifications

- in the API and config loader prototype paths from extensions are added to the front of the prototype paths list. The paths list is traversed in order from front to back, and the first matching prototype is used.

## Result

Prototypes in extension have higher priority than prototypes in default library.

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>