### PR TITLE
Adds support for trace signal

### DIFF
--- a/minemeld/ft/basepoller.py
+++ b/minemeld/ft/basepoller.py
@@ -883,7 +883,11 @@ class BasePollerFT(base.BaseFT):
 
     def mgmtbus_signal(self, source=None, signal=None, **kwargs):
         if signal != 'flush':
-            raise NotImplementedError('Unknown signal {}'.format(signal))
+            super(BasePollerFT, self).mgmtbus_signal(
+                source=source,
+                signal=signal,
+                **kwargs
+            )
             
         self._actor_queue.put(
             (utc_millisec(), 'flush')

--- a/tests/test_ft_base.py
+++ b/tests/test_ft_base.py
@@ -19,6 +19,7 @@ Unit tests for minemeld.ft.base
 
 import unittest
 import mock
+import gevent
 
 import minemeld.ft.base
 import minemeld.ft
@@ -262,3 +263,17 @@ class MineMeldFTBaseTests(unittest.TestCase):
         ochannel.publish.reset_mock()
         b.emit_update('testi', {'type': 'IPv6', 'direction': 'outbound'})
         self.assertEqual(ochannel.publish.call_count, 0)
+
+    def test_full_trace(self):
+        config = {}
+        chassis = mock.Mock()
+
+        bcls = minemeld.ft.base.BaseFT
+
+        b = bcls('test', chassis, config)
+
+        b._disable_full_trace = True
+        b.enable_full_trace(timeout=1)
+        self.assertEqual(b._disable_full_trace, False)
+        gevent.sleep(1.5)
+        self.assertEqual(b._disable_full_trace, True)


### PR DESCRIPTION
## Motivation

MineMeld engine supports an environment variable called _MM_DISABLE_FULL_TRACE_. When the variable is set only a limited set of traces is generated by a node. During troubleshooting it may be useful to enable to full set of traces.

This commit adds a new signal called trace to each node. When _MM_DISABLE_FULL_TRACE_ is set, if a node receives a trace signal the full set of trace messages is generated for 10 minutes and then automatically disabled.

## Modifications

- added new __disable_full_trace_ attribute to minemeld.ft.base.BaseFT to track full trace status
- __disable_full_trace_ is set to _True_ if _MM_DISABLE_FULL_TRACE_ is set, otherwise is set to _False_
- _mgmtbus_signal_ in BaseFT sets __disable_full_trace_ when trace signal is received
- __disable_full_trace_ is reset after 10 mins via a glet

## Result

Now full trace can be enabled in the MineMeld engine on a per node basis.

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>