### PR TITLE
Fix #203

### DIFF
--- a/minemeld/flask/statusapi.py
+++ b/minemeld/flask/statusapi.py
@@ -276,6 +276,9 @@ def generate_local_backup():
     proto_path = config.get('MINEMELD_LOCAL_PROTOTYPE_PATH', None)
     if proto_path is not None:
         args.append(proto_path)
+    certs_path = config.get('MINEMELD_LOCAL_CERTS_PATH', None)
+    if certs_path is not None:
+        args.append(certs_path)
     config_path = os.path.dirname(os.environ.get('MM_CONFIG'))
     args.append(config_path)
 


### PR DESCRIPTION
Fix #203:
- a new variable is read from config MINEMELD_LOCAL_CERTS_PATH with the path of the local cert store
- the contents of the variable is passed to the backup script