### PR TITLE
Adds support for McAfee Web Gateway format and CSV

### DIFF
--- a/minemeld/flask/feedredis.py
+++ b/minemeld/flask/feedredis.py
@@ -15,7 +15,9 @@
 import re
 import cStringIO
 import json
+from contextlib import contextmanager
 
+import unicodecsv
 from netaddr import IPRange, AddrFormatError
 from flask import request, jsonify, Response, stream_with_context
 from flask.ext.login import current_user
@@ -48,6 +50,16 @@ def _translate_ip_ranges(indicator, value=None):
         return [indicator]
 
     return [str(x) if x.size != 1 else str(x.network) for x in ip_range.cidrs()]
+
+
+@contextmanager
+def _buffer():
+    result = cStringIO.StringIO()
+
+    try:
+        yield result
+    finally:
+        result.close()
 
 
 def generate_panosurl_feed(feed, start, num, desc, value, **kwargs):
@@ -168,6 +180,146 @@ def generate_json_feed(feed, start, num, desc, value, **kwargs):
         yield ']\n'
 
 
+def generate_csv_feed(feed, start, num, desc, value, **kwargs):
+    def _is_atomic_type(fv):
+        return (isinstance(fv, unicode) or isinstance(fv, str) or isinstance(fv, int) or isinstance(fv, bool))
+
+    def _format_field_value(fv):
+        if _is_atomic_type(fv):
+            return fv
+
+        if isinstance(fv, list):
+            ok = True
+            for fve in fv:
+                ok &= _is_atomic_type(fve)
+
+            if ok:
+                return ','.join(fv)
+
+        return json.dumps(fv)
+
+    zrange = SR.zrange
+    if desc:
+        zrange = SR.zrevrange
+
+    if num is None:
+        num = (1 << 32)-1
+
+    translate_ip_ranges = kwargs.pop('translate_ip_ranges', False)
+
+    # extract name of fields
+    fields = ['indicator']
+    fields.extend(kwargs.pop('f', []))
+
+    # check if header should be generated
+    header = kwargs.pop('h', None)
+    if header is None:
+        header = True
+    else:
+        header = int(header[0])
+
+    # check if bom should be generated
+    ubom = kwargs.pop('ubom', None)
+    if ubom is None:
+        ubom = False
+    else:
+        ubom = int(ubom[0])
+
+    cstart = start
+
+    if ubom:
+        LOG.debug('BOM')
+        yield '\xef\xbb\xbf'
+
+    with _buffer() as current_line:
+        w = unicodecsv.DictWriter(
+            current_line,
+            fieldnames=fields,
+            encoding='utf-8'
+        )
+
+        if header:
+            w.writeheader()
+            yield current_line.getvalue()
+
+        while cstart < (start+num):
+            ilist = zrange(feed, cstart,
+                           cstart-1+min(start+num - cstart, FEED_INTERVAL))
+
+            for indicator in ilist:
+                v = SR.hget(feed+'.value', indicator)
+                v = None if v is None else json.loads(v)
+
+                xindicators = [indicator]
+                if translate_ip_ranges and '-' in indicator:
+                    xindicators = _translate_ip_ranges(indicator, v)
+
+                for i in xindicators:
+                    fieldvalues = {'indicator': i}
+                    if v is not None and fields:
+                        for f in fields:
+                            if f in v:
+                                fieldvalues[f] = _format_field_value(v[f])
+
+                    current_line.truncate(0)
+                    w.writerow(fieldvalues)
+                    yield current_line.getvalue()
+
+            if len(ilist) < FEED_INTERVAL:
+                break
+
+            cstart += FEED_INTERVAL
+
+
+def generate_mwg_feed(feed, start, num, desc, value, **kwargs):
+    zrange = SR.zrange
+    if desc:
+        zrange = SR.zrevrange
+
+    if num is None:
+        num = (1 << 32)-1
+
+    translate_ip_ranges = kwargs.pop('translate_ip_ranges', False)
+    type_ = kwargs.get('t', None)
+    if type_ is None:
+        type_ = 'string'
+    else:
+        type_ = type_[0]
+    translate_ip_ranges |= type_ == 'ip'
+
+    yield 'type={}\n'.format(type_)
+
+    cstart = start
+    while cstart < (start+num):
+        ilist = zrange(feed, cstart,
+                       cstart-1+min(start+num - cstart, FEED_INTERVAL))
+
+        for indicator in ilist:
+            v = SR.hget(feed+'.value', indicator)
+            v = None if v is None else json.loads(v)
+
+            xindicators = [indicator]
+            if translate_ip_ranges and '-' in indicator:
+                xindicators = _translate_ip_ranges(indicator, v)
+
+            sources = 'from minemeld'
+            if v is not None:
+                sources = v.get('sources', 'from minemeld')
+                if isinstance(sources, list):
+                    sources = ','.join(sources)
+
+            for i in xindicators:
+                yield '"{}" "{}"\n'.format(
+                    i.replace('"', '\\"'),
+                    sources.replace('"', '\\"')
+                )
+
+        if len(ilist) < 100:
+            break
+
+        cstart += 100
+
+
 _FEED_FORMATS = {
     'json': {
         'formatter': generate_json_feed,
@@ -180,6 +332,14 @@ _FEED_FORMATS = {
     'panosurl': {
         'formatter': generate_panosurl_feed,
         'mimetype': 'text/plain'
+    },
+    'mwg': {
+        'formatter': generate_mwg_feed,
+        'mimetype': 'text/plain'
+    },
+    'csv': {
+        'formatter': generate_csv_feed,
+        'mimetype': 'text/csv'
     }
 }
 
@@ -234,6 +394,14 @@ def get_feed_content(feed):
 
     kwargs = {}
     kwargs['translate_ip_ranges'] = int(request.values.get('tr', 0))  # generate IP ranges
+
+    # move to kwargs all the additional parameters, pop the predefined
+    kwargs.update(request.values.to_dict(flat=False))
+    kwargs.pop('s', None)
+    kwargs.pop('n', None)
+    kwargs.pop('d', None)
+    kwargs.pop('v', None)
+    kwargs.pop('tr', None)
 
     mimetype = 'text/plain'
     formatter = generate_plain_feed

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ beautifulsoup4==4.4.1
 cifsdk==2.0.0b7
 lz4==0.8.2
 networkx==1.11
+unicodecsv==0.14.1


### PR DESCRIPTION
## Motivation

Currently MineMeld does not support generating feeds in CSV format or McAfee Web Gateway format. Support for these 2 formats is useful for interoperating with 3rd party systems, like [Splunk Lookup](http://docs.splunk.com/Documentation/Splunk/6.6.0/Knowledge/ConfigureCSVlookups) tables and [McAfee Web Gateway](https://community.mcafee.com/docs/DOC-5208).

## Modifications

- in minemeld.flask.feedredis module added support for McAfee Web Gateway format (see above). Format is selected by setting the _v_ parameter to _mwg_. Supports _tr_ parameter and _t_ parameter for declaring the list type (see McAfee Web Gateway format link above). If _t_ is set to _ip_, _tr_ is automatically set to _true_. Default value for _t_ is _string_.
Example:
```http://<minemeld>/feeds/<feedname>?v=mwg&t=ip```

- in minemeld.flask.feedredis module added support for CSV format. Format is selected by setting the _v_ parameter to _csv_. Supports _tr_ parameter. Encoding is always _utf-8_. Additional parameters:
    - _h_ generates a CSV header. Default _true_
    - _f_ adds a field from the specified indicator attribute. Multiple f parameters can be specified.
    - _ubom_ adds UTF-8 BOM at the beginning of the file. This is for compatibility. Default _false_ 

    Example:
    ```http://<minemeld>/feeds/<feedname>?v=csv&h=1&f=type&f=confidence&f=sources&f=share_level```


## Result

McAfee Web Gateway and CSV formats are supported.

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>