### PR TITLE
Adds lower_timestamp_precision flag to TAXII miner

### DIFF
--- a/minemeld/ft/taxii.py
+++ b/minemeld/ft/taxii.py
@@ -93,6 +93,7 @@ class TaxiiClient(basepoller.BasePollerFT):
         self.ignore_composition_operator = self.config.get('ignore_composition_operator', False)
         self.create_fake_indicator = self.config.get('create_fake_indicator', False)
         self.hash_priority = self.config.get('hash_priority', _STIX_MINEMELD_HASHES)
+        self.lower_timestamp_precision = self.config.get('lower_timestamp_precision', False)
 
         self.discovery_service = self.config.get('discovery_service', None)
         self.collection = self.config.get('collection', None)
@@ -1105,6 +1106,10 @@ class TaxiiClient(basepoller.BasePollerFT):
 
         end = datetime.fromtimestamp(now/1000)
         end = end.replace(tzinfo=pytz.UTC)
+
+        if self.lower_timestamp_precision:
+            end = end.replace(second=0, microsecond=0)
+            begin = begin.replace(second=0, microsecond=0)
 
         return self._incremental_poll_collection(
             taxii_client=tc,


### PR DESCRIPTION
## Motivation

Some TAXII Servers do not support timestamps with second. precision and throw an error when a poll request is performed with timestamps including seconds.

## Modifications

- a new flag is added to TAXII Miner to support stripping seconds from timestamps. When _ lower_timestamp_precision_ is set to _true_, the begin and end timestamps of the poll requests are stripped of the seconds.

## Result

New flag for TAXII Miner to improve compatibility with specific TAXII Servers.

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>