### PR TITLE
Added missing required module unicodecsv for requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ tox==2.1.1
 mock==1.3.0
 git+https://github.com/PaloAltoNetworks-BD/platter#egg=platter
 cython==0.24
+unicodecsv==0.14.1


### PR DESCRIPTION
The module unicodecsv is now needed as part of change https://github.com/PaloAltoNetworks/minemeld-core/commit/ed43c1fac190b98d9c0fc4dcb7736cccfcef8070 but wasn't included in requirements-dev.txt. This stops the minemeld-ansible building a working dev environment. It has been added to requirements-dev.txt

Signed-off-by: Simon Coggins <s.coggins@cqu.edu.au>