### PR TITLE
Improved restore utility to revert candidate to running after restore

### DIFF
--- a/minemeld/flask/configapi.py
+++ b/minemeld/flask/configapi.py
@@ -32,8 +32,11 @@ __all__ = ['BLUEPRINT']
 
 
 FEED_INTERVAL = 100
+
+# these should be in sync with restore.py
 REDIS_KEY_PREFIX = 'mm:config:'
 REDIS_KEY_CONFIG = REDIS_KEY_PREFIX+'candidate'
+
 REDIS_NODES_LIST = 'nodes'
 LOCK_TIMEOUT = 3000
 


### PR DESCRIPTION
Now the restore utility deletes the existing candidate and restart the API process to trigger a revert.

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>