### PR TITLE
Fix for ATF-3245

### DIFF
--- a/minemeld/flask/metricsapi.py
+++ b/minemeld/flask/metricsapi.py
@@ -14,6 +14,7 @@
 
 import os
 import os.path
+import hashlib
 
 import rrdtool
 
@@ -200,6 +201,7 @@ def get_node_metrics(node):
 
     type_ = request.args.get('t', None)
 
+    node = hashlib.md5(node).hexdigest()[:10]
     metrics = _list_metrics(prefix=node+'.')
 
     cc = minemeld.collectd.CollectdClient(RRD_SOCKET_PATH)
@@ -240,6 +242,7 @@ def get_metric(node, metric):
 
     type_ = request.args.get('t', 'minemeld_counter')
 
+    node = hashlib.md5(node).hexdigest()[:10]
     metric = node+'.'+metric
 
     if metric not in _list_metrics():

--- a/minemeld/mgmtbus.py
+++ b/minemeld/mgmtbus.py
@@ -33,6 +33,7 @@ import logging
 import uuid
 import collections
 import time
+import hashlib
 
 import gevent
 import gevent.event
@@ -333,6 +334,7 @@ class MgmtbusMaster(object):
             length = a.get('length', None)
 
             _, _, source = source.split(':', 2)
+            source = hashlib.md5(source).hexdigest()[:10]
 
             for m, v in stats.iteritems():
                 gstats[ntype+'.'+m] += v


### PR DESCRIPTION
Now metrics are stored are stored with a name derived from MD5 to avoid problems with long names while avoiding collisions.

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>