### PR TITLE
Remove dep on get_installed_distributions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@ iDev <zero.line@gmail.com>
 Jonas Eichinger <jonas.eichinger@unisys.com>
 Egon Kidmose <kidmose@gmail.com>
 Dan James <sddj@me.com>
+John Marion <jmarion-ext@arista.com>

--- a/minemeld/loader.py
+++ b/minemeld/loader.py
@@ -2,16 +2,8 @@ import logging
 
 import pip
 
-from pkg_resources import WorkingSet, _initialize_master_working_set, parse_version
+from pkg_resources import working_set, WorkingSet
 from collections import namedtuple
-
-try:
-    if parse_version(pip.__version__) >= parse_version('10.0.0'):
-        from pip._internal import get_installed_distributions  # pylint: disable=E0611,E0401
-    else:
-        from pip import get_installed_distributions  # pylint: disable=E0611,E0401
-except:
-    pass
 
 LOG = logging.getLogger(__name__)
 
@@ -30,15 +22,6 @@ MMEntryPoint = namedtuple(
 _ENTRYPOINT_GROUPS = {}
 
 _WS = None
-
-
-def _installed_versions():
-    if parse_version(pip.__version__) >= parse_version('10.0.0'):
-        installed_dists = get_installed_distributions(local_only=False)
-    else:
-        installed_dists = get_installed_distributions()
-
-    return {d.project_name: d for d in installed_dists}
 
 
 def _conflicts(requirements, installed):
@@ -63,10 +46,9 @@ def _conflicts(requirements, installed):
 def _initialize_entry_point_group(entrypoint_group):
     global _WS
 
-    installed = _installed_versions()
+    installed = {d.project_name: d for d in working_set}
 
     if _WS is None:
-        _initialize_master_working_set()
         _WS = WorkingSet()
 
     cache = {}


### PR DESCRIPTION
This causes issues with the latest pip 18, where get_installed_distributions doesn't exist (even in _internal). It's clear pip doesn't intend for that function to be used. I've changed the call to use the suggestion on pip's issue [0], but I don't know enough about this part of Python to know if that has unintended side effects. Someone in-the-know should look at this before merging.

[0] pypa/pip#5243