### PR TITLE
Adds support for duplicating wildcarded URLs

### DIFF
--- a/minemeld/flask/feedredis.py
+++ b/minemeld/flask/feedredis.py
@@ -85,6 +85,12 @@ def generate_panosurl_feed(feed, start, num, desc, value, **kwargs):
             i = _PROTOCOL_RE.sub('', i)
             i = _INVALID_TOKEN_RE.sub('*', i)
 
+            # for PAN-OS *.domain.com does not match domain.com
+            # we should provide both
+            # this could generate more than num entries in the egress feed
+            if i.startswith('*.'):
+                yield i[2:] + '\n'
+
             yield i + '\n'
 
         if len(ilist) < 100:


### PR DESCRIPTION
In PAN-OS, a wildcard URL like `*.domain.com` from EDLs does not match a hostname without a leading component like `domain.com`. This PR implements and improvement on the `panosurl` modifier to duplicate URLs starting with a wildcard into 2 entries:
- before:
```
*.domain.com
```

- after: 
```
*.domain.com
domain.com
```

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>