### PR TITLE
Implements output feed for STIX/TAXII 2

### DIFF
--- a/minemeld/comm/zmqredis.py
+++ b/minemeld/comm/zmqredis.py
@@ -182,7 +182,7 @@ class ZMQRpcFanoutClientChannel(object):
                 })
                 self.active_rpcs.pop(id_)
 
-            gevent.sleep(0)
+            gevent.sleep(0.001)
 
     def send_rpc(self, method, params=None, num_results=0, and_discard=False):
         if self.socket is None:
@@ -225,7 +225,7 @@ class ZMQRpcFanoutClientChannel(object):
         ])
         LOG.debug('RPC Fanout Client: send multipart to {}: {!r} - done'.format(self.fanout, json.dumps(body)))
 
-        gevent.sleep(0)
+        gevent.sleep(0.001)
 
         return event
 
@@ -404,7 +404,7 @@ class ZMQPubChannel(object):
         except zmq.ZMQError:
             LOG.error('Topic {} queue full - dropping message'.format(self.topic))
 
-        gevent.sleep(0)
+        gevent.sleep(0.001)
 
     def connect(self, context):
         if self.socket is not None:

--- a/minemeld/flask/__init__.py
+++ b/minemeld/flask/__init__.py
@@ -81,6 +81,7 @@ def create_app():
     from . import logsapi  # noqa
     from . import extensionsapi  # noqa
     from . import jobsapi  # noqa
+    from . import taxii2 # noqa
 
     configapi.init_app(app)
     extensionsapi.init_app(app)
@@ -102,6 +103,9 @@ def create_app():
     app.register_blueprint(logsapi.BLUEPRINT)
     app.register_blueprint(extensionsapi.BLUEPRINT)
     app.register_blueprint(jobsapi.BLUEPRINT)
+
+    if config.get('ENABLE_TAXII2', False):
+        app.register_blueprint(taxii2.BLUEPRINT)
 
     # install blueprints from extensions
     for apiname, apimmep in minemeld.loader.map(minemeld.loader.MM_API_ENTRYPOINT).iteritems():

--- a/minemeld/flask/feedredis.py
+++ b/minemeld/flask/feedredis.py
@@ -414,7 +414,7 @@ def generate_carbon_black(feed, start, num, desc, value, **kwargs):
     report_args = dict()
     report_args["id"] = feed + "_report"
 
-    report_title = kwargs.get('rt', ["MieneMeld Generated Report"])
+    report_title = kwargs.get('rt', ["MineMeld Generated Report"])
     if report_title is not None:
         report_title = report_title[0]
     report_args["title"] = report_title

--- a/minemeld/flask/taxii2/__init__.py
+++ b/minemeld/flask/taxii2/__init__.py
@@ -1,0 +1,112 @@
+#  Copyright 2019 Palo Alto Networks, Inc
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import uuid
+
+from flask import request, jsonify
+from flask_login import current_user
+
+from .. import config
+from ..aaa import MMBlueprint
+from ..logger import LOG
+
+from .utils import get_taxii2_feeds, get_feed_id
+from .collection import generate_stix2_bundle
+
+
+__all__ = ['BLUEPRINT']
+
+
+BLUEPRINT = MMBlueprint('taxii2', __name__, url_prefix='/taxii')
+
+@BLUEPRINT.route('/', methods=['GET'], feeds=True, read_write=False)
+def get_taxii2_server():
+    taxii_feeds = get_taxii2_feeds()
+    authorized = next(
+        (tf for tf in taxii_feeds if current_user.check_feed(tf['name'])),
+        None
+    )
+    if authorized is None:
+        return 'Unauthorized', 401
+
+    response = jsonify(title='MineMeld TAXII Server')
+    response.headers['Content-Type'] = 'application/vnd.oasis.taxii+json; version=2.0'
+    return response
+
+
+@BLUEPRINT.route('/api/', methods=['GET'], feeds=True, read_write=False)
+def get_apiroot():
+    taxii_feeds = get_taxii2_feeds()
+    authorized = next(
+        (tf for tf in taxii_feeds if current_user.check_feed(tf['name'])),
+        None
+    )
+    if authorized is None:
+        return 'Unauthorized', 401
+
+    response = jsonify(
+        title='MineMeld',
+        versions=['taxii-2.0'],
+        max_content_length=1024
+    )
+    response.headers['Content-Type'] = 'application/vnd.oasis.taxii+json; version=2.0'
+    return response
+
+
+@BLUEPRINT.route('/api/collections/', methods=['GET'], feeds=True, read_write=False)
+def get_collections():
+    taxii_feeds = get_taxii2_feeds()
+    authorized = [tf for tf in taxii_feeds if current_user.check_feed(tf['name'])]
+    if len(authorized) == 0:
+        return 'Unauthorized', 401
+
+    response = jsonify(collections=[dict(title=feed['name'], id=feed['taxii2_id'], can_read=True, can_write=False) for feed in authorized])
+    response.headers['Content-Type'] = 'application/vnd.oasis.taxii+json; version=2.0'
+    return response
+
+
+@BLUEPRINT.route('/api/collections/<collection>/', methods=['GET'], feeds=True, read_write=False)
+def get_collection(collection):
+    taxii_feeds = get_taxii2_feeds()
+    authorized = [tf for tf in taxii_feeds if current_user.check_feed(tf['name'])]
+    if len(authorized) == 0:
+        return 'Unauthorized', 401
+
+    collection_details = next(
+        (c for c in authorized if c['taxii2_id'] == collection),
+        None
+    )
+    if collection_details is None:
+        return 'Unauthorized', 401
+
+    response = jsonify(title=collection_details['name'], id=collection_details['taxii2_id'], can_read=True, can_write=False)
+    response.headers['Content-Type'] = 'application/vnd.oasis.taxii+json; version=2.0'
+    return response
+
+
+@BLUEPRINT.route('/api/collections/<collection>/objects/', methods=['GET'], feeds=True, read_write=False)
+def get_collection_objects(collection):
+    taxii_feeds = get_taxii2_feeds()
+    authorized = [tf for tf in taxii_feeds if current_user.check_feed(tf['name'])]
+    if len(authorized) == 0:
+        return 'Unauthorized', 401
+
+    collection_details = next(
+        (c for c in authorized if c['taxii2_id'] == collection),
+        None
+    )
+    if collection_details is None:
+        return 'Unauthorized', 401
+
+    return generate_stix2_bundle(collection_details['name'])

--- a/minemeld/flask/taxii2/collection.py
+++ b/minemeld/flask/taxii2/collection.py
@@ -1,0 +1,145 @@
+#  Copyright 2019 Palo Alto Networks, Inc
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import uuid
+import cStringIO
+from collections import defaultdict
+
+import ujson as json
+from flask import request, jsonify, stream_with_context, Response
+from flask_login import current_user
+from netaddr import IPRange, AddrFormatError
+
+from ..redisclient import SR
+from ..logger import LOG
+
+from .stix2 import stix2_converter
+from .utils import get_ioc_property
+
+
+FEED_INTERVAL = 100
+
+
+def translate_ip_ranges(indicator):
+    try:
+        ip_range = IPRange(*indicator.split('-', 1))
+
+    except (AddrFormatError, ValueError, TypeError):
+        return [indicator]
+
+    return [str(x) if x.size != 1 else str(x.network) for x in ip_range.cidrs()]
+
+
+def stix2_bundle_formatter(feedname):
+    authz_property = get_ioc_property(feedname)
+
+    bundle_id = str(uuid.uuid3(
+        uuid.NAMESPACE_URL,
+        ('minemeld/{}/{}'.format(feedname, 0)).encode('ascii', 'ignore')
+    ))
+
+    last_entry = SR.zrange(feedname, -1, -1, withscores=True)
+    LOG.debug(last_entry)
+    if len(last_entry) != 0:
+        _, score = last_entry[0]
+        bundle_id = str(uuid.uuid3(
+            uuid.NAMESPACE_URL,
+            ('minemeld/{}/{}'.format(feedname, score)).encode('ascii', 'ignore')
+        ))
+
+    yield '{{\n"type": "bundle",\n"spec_version": "2.0",\n"id": "bundle--{}",\n"indicators": [\n'.format(bundle_id)
+
+    start = 0
+    num = (1 << 32) - 1
+
+    identities = defaultdict(uuid.uuid4)
+    cstart = 0
+    firstelement = True
+    while cstart < (start + num):
+        ilist = SR.zrange(
+                    feedname, cstart,
+                    cstart - 1 + min(start + num - cstart, FEED_INTERVAL)
+                )
+
+        result = cStringIO.StringIO()
+
+        for indicator in ilist:
+            v = SR.hget(feedname + '.value', indicator)
+
+            if v is None:
+                continue
+            v = json.loads(v)
+
+            if authz_property is not None:
+                # authz_property is defined in config
+                ioc_tags = v.get(authz_property, None)
+                if ioc_tags is not None:
+                    # authz_property is defined inside the ioc value
+                    ioc_tags = set(ioc_tags)
+                    if not current_user.can_access(ioc_tags):
+                        # user has no access to this ioc
+                        continue
+
+            xindicators = [indicator]
+            if '-' in indicator and v.get('type', None) in ['IPv4', 'IPv6']:
+                xindicators = translate_ip_ranges(indicator)
+
+            for i in xindicators:
+                try:
+                    converted = stix2_converter(i, v, feedname)
+                except RuntimeError:
+                    LOG.error('Error converting {!r} to STIX2'.format(i))
+                    continue
+
+                created_by_ref = converted.pop('_created_by_ref', None)
+                if created_by_ref is not None:
+                    converted['created_by_ref'] = 'identity--'+str(identities[created_by_ref])
+
+                if not firstelement:
+                    result.write(',')
+                firstelement = False
+
+                result.write(json.dumps(converted, escape_forward_slashes=False))
+
+        yield result.getvalue()
+
+        result.close()
+
+        if len(ilist) < 100:
+            break
+
+        cstart += 100
+
+    # dump identities
+    result = cStringIO.StringIO()
+    for identity, uuid_ in identities.iteritems():
+        identity_class, name = identity.split(':', 1)
+        result.write(',')
+        result.write(json.dumps({
+            'type': 'identty',
+            'id': 'identity--'+str(uuid_),
+            'name': name,
+            'identity_class': identity_class
+        }))
+    yield result.getvalue()
+    result.close()
+
+    yield ']\n}'
+
+
+def generate_stix2_bundle(feedname):
+    return Response(
+        stream_with_context(stix2_bundle_formatter(feedname)),
+        mimetype='application/vnd.oasis.stix+json; version=2.0'
+    )

--- a/minemeld/flask/taxii2/stix2.py
+++ b/minemeld/flask/taxii2/stix2.py
@@ -1,0 +1,139 @@
+import uuid
+from datetime import datetime
+
+from ..logger import LOG
+
+
+TLP_MARKING_DEFINITIONS = {
+    'white': 'marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9',
+    'green': 'marking-definition--34098fce-860f-48ae-8e50-ebd3cc5e41da',
+    'amber': 'marking-definition--f88d31f6-486f-44da-b317-01333bde0b82',
+    'red': 'marking-definition--5e57c739-391a-4eb3-b6be-7d15ca92d5ed'
+}
+
+
+TYPE_CONVERSION = {
+    'IPv4': 'ipv4-addr:value',
+    'IPv6': 'ipv6-addr:value',
+    'domain': 'domain-name:value',
+    'URL': 'url:value',
+    'sha256': "file:hashes.'SHA-256'",
+    'sha1': "file:hashes.'SHA-1'",
+    'sha512': "file:hashes.'SHA-512'",
+    'md5': "file:hashes.MD5",
+    'ssdeep': "file:hashes.ssdeep"
+}
+
+
+NAME_ATTRIBUTES = [
+    'stix2_name',
+    'stix_title',
+    'stix_package_title'
+]
+
+
+DESCRIPTION_ATTRIBUTES = [
+    'stxi2_description',
+    'stix_description',
+    'stix_package_description'
+]
+
+
+def _indicator_to_pattern(indicator, type_):
+    stix2_pattern = TYPE_CONVERSION.get(type_, None)
+    if stix2_pattern is None:
+        raise RuntimeError('Unhandled type {!r}'.format(type_))
+
+    return "{} = '{}'".format(stix2_pattern, indicator)
+
+
+def _get_name(indicator, type_, value):
+    result = value.get('stix2_name', None)
+    if result is not None:
+        return result
+
+    return '{} indicator: {}'.format(type_, indicator)
+
+
+def _get_name(indicator, type_, value):
+    result = value.get('stix2_name', None)
+    if result is not None:
+        return result
+
+    return '{} indicator: {}'.format(type_, indicator)
+
+
+def _get_description(indicator, type_, value):
+    result = value.get('stix2_description', None)
+    if result is not None:
+        return result
+
+    return '{} indicator {}, received from {}'.format(
+        type_,
+        indicator,
+        ', '.join(value.get('sources', []))
+    )
+
+
+def _get_id(indicator, type_, value):
+    result = value.get('stix2_id', None)
+    if result is not None:
+        return result
+
+    return 'indicator--'+str(uuid.uuid3(uuid.NAMESPACE_URL, 'minemeld/{}/{}/{}'.format(
+        value.get('type', 'unknown'),
+        indicator,
+        value.get('last_seen', 0)
+    )))
+
+
+def _additional_properties(indicator, type_, value):
+    result = {}
+
+    labels = value.get('stix2_labels', None)
+    if labels is not None:
+        result['labels'] = labels
+
+    information_source = value.get('stix_information_source', None)
+    if information_source is not None:
+        result['_created_by_ref'] = 'organization:'+information_source
+
+    created_by_ref = value.get('stix2_created_by', None)
+    if created_by_ref is not None:
+        result['_created_by_ref'] = created_by_ref
+
+    return result
+
+
+def stix2_converter(indicator, value, feedname=''):
+    type_ = value.get('type', None)
+    if type_ is None:
+        raise RuntimeError('No type in indicator')
+
+    result = {
+        'type': 'indicator',
+        'name': _get_name(indicator, type_, value),
+        'description': _get_description(indicator, type_, value),
+        'id': _get_id(indicator, type_, value),
+        'pattern': _indicator_to_pattern(indicator, type_)
+    }
+    
+    last_seen = value.get('last_seen', None)
+    if last_seen is not None:
+        result['modified'] = datetime.utcfromtimestamp(last_seen/1000).isoformat()+'Z'
+
+    first_seen = value.get('first_seen', None)
+    if first_seen is not None:
+        first_seen = datetime.utcfromtimestamp(last_seen/1000).isoformat()+'Z'
+        result['valid_from'] = first_seen
+        result['created'] = first_seen
+    else:
+        result['valid_from'] = datetime.utcnow().isoformat()+'Z'
+
+    share_level = value.get('share_level', None)
+    if share_level is not None and share_level in TLP_MARKING_DEFINITIONS:
+        result['object_marking_refs'] = [TLP_MARKING_DEFINITIONS[share_level]]
+
+    result.update(_additional_properties(indicator, type_, value))
+
+    return result

--- a/minemeld/flask/taxii2/utils.py
+++ b/minemeld/flask/taxii2/utils.py
@@ -1,0 +1,37 @@
+import uuid
+
+from .. import config
+from ..mmrpc import MMMaster
+
+def get_taxii2_feeds():
+    # check if feed exists
+    status = MMMaster.status()
+    status = status.get('result', None)
+    if status is None:
+        raise RuntimeError('Error retrieving engine status')
+
+    result = []
+    for node, node_status in status.iteritems():
+        class_ = node_status.get('class', None)
+        if class_ != 'minemeld.ft.redis.RedisSet':
+            continue
+
+        _, _, feedname = node.split(':', 2)
+        result.append(dict(name=feedname, taxii2_id=get_feed_id(feedname)))
+
+    return result
+
+
+def get_feed_id(feedname):
+    return str(uuid.uuid3(uuid.NAMESPACE_URL, ('minemeld/'+feedname).encode('ascii', 'ignore')))
+
+
+def get_ioc_property(feedname):
+    if not config.get('FEEDS_AUTH_ENABLED', False):
+        return None
+
+    fattributes = config.get('FEEDS_ATTRS', None)
+    if fattributes is None or feedname not in fattributes:
+        return None
+
+    return fattributes[feedname].get('ioc_tags_property', None)


### PR DESCRIPTION
## Motivation

Current version of MineMeld offers no support for STIX/TAXIIv2

## Modifications

- implemented partial support for STIX/TAXII v2.0
- added new TAXIIv2 endpoints:
  + `/taxii/` discovery endpoint
  + `/taxii/api/` API root (unique for the MM instance)
  + `/taxii/api/collections/` list collections. A collection is advertised for each multiformat output node (minemeld.ft.redis). Basically, each feed output node is also advertised as a STIX/TAXII2 collection
  + `/taxii/api/collections/<collection-id>/` collection details
  + `/taxii/api/collections/<collection-id>/objects/` feed of indicators in STIX2 format
- indicators are converted on the fly in STIX2 format. If the indicators were originated from STIX2/STIX1 feeds, the STIX2 and STIX1 properties are translated back into the STIX2 properties
- added an additional layer of authorization at the indicator level: it is now possible to specify a property in the indicator that contains a set of tags to be matched against that specific feed user tags. Only if there is a match, the IOC is provided in the feed.
- by default this functionality is disabled, `ENABLE_TAXII2` should be set to true in the API config to enable STIX/TAXII2 output nodes

## Result

A preliminary, limited support for STIX/TAXII2 is provided.

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>