### PR TITLE
Look for correct version in list of possible versions

### DIFF
--- a/minemeld/ft/taxii.py
+++ b/minemeld/ft/taxii.py
@@ -357,7 +357,7 @@ class TaxiiClient(basepoller.BasePollerFT):
             LOG.info('{} - message binding: {}'.format(
                 self.name, pi.poll_message_bindings
             ))
-            if pi.poll_message_bindings[0] == libtaxii.constants.VID_TAXII_XML_11:
+            if libtaxii.constants.VID_TAXII_XML_11 in pi.poll_message_bindings:
                 self.poll_service = pi.poll_address
                 LOG.info('{} - poll service found'.format(self.name))
                 break


### PR DESCRIPTION
Look for correct version in list of possible versions
## Description

Changed logic in minemeld.ft.taxii.py to look for appropriate version in a list of available versions as opposed to comparing first version in list to what we want.

## Motivation and Context

fixes #337 

## How Has This Been Tested?

I have used this change in a custom written extension based on this miner.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [N/A] I have updated the documentation accordingly.
- [N/A] I have read the **CONTRIBUTING** document.
- [N/A] I have added tests to cover my changes if appropriate.
- [N/A ] All new and existing tests passed.
