### PR TITLE
Update taxii.py

### DIFF
--- a/minemeld/ft/taxii.py
+++ b/minemeld/ft/taxii.py
@@ -357,7 +357,7 @@ class TaxiiClient(basepoller.BasePollerFT):
             LOG.info('{} - message binding: {}'.format(
                 self.name, pi.poll_message_bindings
             ))
-            if pi.poll_message_bindings[0] == libtaxii.constants.VID_TAXII_XML_11:
+            if libtaxii.constants.VID_TAXII_XML_11 in pi.poll_message_bindings:
                 self.poll_service = pi.poll_address
                 LOG.info('{} - poll service found'.format(self.name))
                 break


### PR DESCRIPTION
Changed message binding handling

## Description

Updated the Taxii message binding handling.

## Motivation and Context

Taxii service can return multiple supported message versions such as 1.0 and 1.1.

## How Has This Been Tested?

Tested this inline on a running minemeld instance against two seperate taxii servers.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
